### PR TITLE
Prevent errors from unorthodox topics_strings

### DIFF
--- a/app/models/concerns/topicable.rb
+++ b/app/models/concerns/topicable.rb
@@ -14,8 +14,8 @@ module Topicable
     topics_array = []
     topic_names_array.each do |topic_name|
       topic = game.user.topics.where('lower(name) = ?', topic_name.downcase)
-                  .first_or_create!(name: topic_name)
-      topics_array << topic
+                  .first_or_create(name: topic_name)
+      topics_array << topic if topic.valid?
     end
     self.topics = topics_array
   end
@@ -25,5 +25,6 @@ module Topicable
                  .squeeze(' ')          # Compress any consecutive spaces.
                  .gsub(/\s?,\s?/, ',')  # Remove any whitespace around commas.
                  .split(',')            # Convert to array of strings.
+                 .uniq(&:downcase)      # Remove any duplicates from array.
   end
 end


### PR DESCRIPTION
Previously, if the user had two commas with no non-whitespace characters
in between, Topicable would attempt to create a new topic with the empty
string as a name, which raised an error and caused the entire save to
fail. Remedy this by only adding a topic to the list if it's valid.

Also, if the user entered the same topic name twice in the same string,
this would cause the save to fail, due to violation of the topic-name
uniqueness constraint. Remove any duplicates (case-insensitively) from
the array before hitting the database.
