### PR TITLE
Add Conflict flag to gameData

### DIFF
--- a/app/assets/javascripts/games.js.erb
+++ b/app/assets/javascripts/games.js.erb
@@ -558,16 +558,17 @@ $( ".games-game" ).ready( function() {
         // data.match will be truthy iff currentGame's final id
         // matches up with a valid game in the database belonging
         // to the currently-logged-in user.
+        // Set the "conflict" flag in currentGameData if there is
+        // non-matching category ID data in currentGame.
         if ( data.match ) {
           disableShowDate();
+          currentGameData["conflict"] = false;
         } else {
           enableShowDate();
-          // If we're in this block, the category IDs are incorrect.
-          // Remove them.
-          updateCategoryIds( { ids: [ null, null, null, null, null, null, null,
-                                      null, null, null, null, null, null ] } );
+          currentGameData["conflict"] = true;
           enableSaveLink();
         }
+        setCookie( "gameData", currentGameData );
       },
       dataType: "json"
     });
@@ -873,9 +874,17 @@ $( ".games-game" ).ready( function() {
   });
 
   $saveLink.on( "click", function() {
-    // Make the Ajax request iff the save link is not disabled.
+    // Take action only if the save link is not disabled.
     if ( !$saveLink.data( "disabled" ) ) {
       disableSaveLink( "Saving&hellip;" );
+
+      // If the conflict (between cookie and database) flag was set when
+      // the page was loaded, remove the category IDs from currentGame.
+      if (currentGameData["conflict"]) {
+        updateCategoryIds( { ids: [ null, null, null, null, null, null, null,
+                                    null, null, null, null, null, null ] } );
+      }
+      currentGameData["conflict"] = false;
 
       $.ajax({
         method: "POST",
@@ -885,6 +894,8 @@ $( ".games-game" ).ready( function() {
         error: function( data ) { saveErrorHandler( data ); },
         dataType: "json"
       });
+
+      setCookie( "gameData", currentGameData );
     }
   });
 

--- a/app/assets/javascripts/games.js.erb
+++ b/app/assets/javascripts/games.js.erb
@@ -72,6 +72,7 @@ function newCookie() {
 
 const NEW_DATA_COOKIE = {
   "modified":false,
+  "conflict":false,
   "activeRound":"round_one_categories"
 };
 
@@ -558,8 +559,6 @@ $( ".games-game" ).ready( function() {
         // data.match will be truthy iff currentGame's final id
         // matches up with a valid game in the database belonging
         // to the currently-logged-in user.
-        // Set the "conflict" flag in currentGameData if there is
-        // non-matching category ID data in currentGame.
         if ( data.match ) {
           disableShowDate();
           currentGameData["conflict"] = false;
@@ -884,7 +883,6 @@ $( ".games-game" ).ready( function() {
         updateCategoryIds( { ids: [ null, null, null, null, null, null, null,
                                     null, null, null, null, null, null ] } );
       }
-      currentGameData["conflict"] = false;
 
       $.ajax({
         method: "POST",
@@ -895,6 +893,7 @@ $( ".games-game" ).ready( function() {
         dataType: "json"
       });
 
+      currentGameData["conflict"] = false;
       setCookie( "gameData", currentGameData );
     }
   });


### PR DESCRIPTION
Refrain from removing conflicting IDs until save

Create a "conflict" flag that is set when the cookie's Final ID doesn't
match a game in the database belonging to the currently-logged-in user.

If a save is attempted with the flag set, only then remove the IDs.
