### PR TITLE
A bunch of random touchups

### DIFF
--- a/app/assets/javascripts/games.js.erb
+++ b/app/assets/javascripts/games.js.erb
@@ -154,7 +154,16 @@ $( ".games-game" ).ready( function() {
     $overlayCat.html( catName );
     $overlayValue.html( "$" + clueValue);
 
+    setOverlayData();
+  }
+
+  function setOverlayData() {
     $ddCheckbox.prop( "checked", $currentClue.data( "isdd" ) );
+
+    $buttonRight.toggleClass( "active", $currentClue.hasClass( "clue-right" ) );
+    $buttonWrong.toggleClass( "active", $currentClue.hasClass( "clue-wrong" ) );
+    $buttonPass.toggleClass( "active", $currentClue.hasClass( "clue-pass" ) );
+    $buttonNR.toggleClass( "active", $currentClue.hasClass( "clue-nr" ) );
   }
 
   function hideOverlay() {
@@ -183,13 +192,32 @@ $( ".games-game" ).ready( function() {
     $currentClue.html( "<span>" + html + "</span>" );
     var col = $currentClue.data( "column" );
     var row = $currentClue.data( "row" );
-    var currentClueState = currentGame[currentRound][col - 1]["result" + row]
-    $currentClue.data( "boxstate", boxstate );
-    $currentClue.toggleClass( "active-clue-box", boxActive );
+    var currentClueState = currentGame[currentRound][col - 1]["result" + row];
+    setClueData( boxstate, boxActive );
     setDD( ddCheckboxState() );
     if ( addDD && ddCheckboxState() ) { statusCode += 4; }
     currentGame[currentRound][col - 1]["result" + row] = statusCode;
     updateCookies( currentClueState !== statusCode );
+  }
+
+  function setClueData( boxstate, boxActive ) {
+    $currentClue.data( "boxstate", boxstate );
+    $currentClue.removeClass( "clue-right clue-wrong clue-pass clue-nr" );
+    switch ( boxstate ) {
+      case "right":
+        $currentClue.addClass( "clue-right" );
+        break;
+      case "wrong":
+        $currentClue.addClass( "clue-wrong" );
+        break;
+      case "pass":
+        $currentClue.addClass( "clue-pass" );
+        break;
+      case "nr":
+        $currentClue.addClass( "clue-nr" );
+        break;
+    }
+    $currentClue.toggleClass( "active-clue-box", boxActive );
   }
 
   function setDD( bool ) {
@@ -734,7 +762,7 @@ $( ".games-game" ).ready( function() {
   var $buttonRight = $( "#button-right" );
   var $buttonPass = $( "#button-pass" );
   var $buttonWrong = $( "#button-wrong" );
-  var $buttonNR = $( "#button-nr" );
+  var $buttonNR = $( "#button-nr button" );
   var $ddCheckbox = $( "#dd-checkbox" );
   var $resetLink = $( "#reset-link" );
   var $cancelLink = $( "#cancel-link" );

--- a/app/assets/javascripts/games.js.erb
+++ b/app/assets/javascripts/games.js.erb
@@ -120,15 +120,23 @@ $( ".games-game" ).ready( function() {
     switch ( currentGame["final"]["result"] ) {
       case 0:
         $finalSymbol.html("");
+        $buttonFJRight.removeClass( "active" );
+        $buttonFJWrong.removeClass( "active" );
         break;
       case 1:
         $finalSymbol.html( "&nbsp;&#x2718;" );
+        $buttonFJRight.removeClass( "active" );
+        $buttonFJWrong.addClass( "active" );
         break;
       case 3:
         $finalSymbol.html( "&nbsp;&#x2713;" );
+        $buttonFJRight.addClass( "active" );
+        $buttonFJWrong.removeClass( "active" );
         break;
       default:
         $finalSymbol.html( "&nbsp;?" );
+        $buttonFJRight.removeClass( "active" );
+        $buttonFJWrong.removeClass( "active" );
         break;
     }
   }

--- a/app/assets/stylesheets/master.css.scss
+++ b/app/assets/stylesheets/master.css.scss
@@ -654,6 +654,14 @@ input {
             font-size: 10vh;
             margin: 3vh 0;
           }
+
+          #button-final-right.active {
+            background-color: $check-light-green;
+          }
+
+          #button-final-wrong.active {
+            background-color: $x-light-red;
+          }
         }
 
         #final-contestant-results {
@@ -681,7 +689,15 @@ input {
               padding: 1vh 1vw;
             }
 
-            .btn-default.fj-button.active {
+            .btn-default.fj-button.fj-right.active {
+              background-color: $check-light-green;
+            }
+
+            .btn-default.fj-button.fj-wrong.active {
+              background-color: $x-light-red;
+            }
+
+            .btn-default.fj-button.fj-dnp.active {
               background-color: $j-lighter-blue;
             }
           }

--- a/app/assets/stylesheets/master.css.scss
+++ b/app/assets/stylesheets/master.css.scss
@@ -17,6 +17,12 @@ $j-yellow:       #cf9f3e;
 $j-shadow:       #101014;
 $dd-border:      #674f1f;
 
+$check-green: #00ff00;
+$check-light-green: #88ff88;
+
+$x-red: #ff0000;
+$x-light-red: #ff8888;
+
 /* universal */
 
 *{
@@ -425,6 +431,18 @@ input {
           cursor: default;
         }
 
+        .clue-box.clue-right {
+          color: $check-green;
+        }
+
+        .clue-box.clue-wrong {
+          color: $x-red;
+        }
+
+        .clue-box.clue-pass {
+          color: $j-lighter-blue;
+        }
+
         .active-clue-box:hover {
           background-color: $j-light-blue;
         }
@@ -486,6 +504,18 @@ input {
             font-size: 10vh;
             margin: 3vh 0;
           }
+
+          #button-right.active {
+            background-color: $check-light-green;
+          }
+
+          #button-wrong.active {
+            background-color: $x-light-red;
+          }
+
+          #button-pass.active {
+            background-color: $j-lighter-blue;
+          }
         }
 
         #dd-nr-cancel {
@@ -524,6 +554,10 @@ input {
             height: 100%;
             width: 100%;
             font-size: 10vh;
+          }
+
+          #button-nr button.active {
+            background-color: $j-lighter-blue;
           }
 
           a {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ActiveRecord::Base
   validates :email, length: { maximum: 50 },
                     format: { with: VALID_EMAIL_REGEX },
                     uniqueness: { case_sensitive: false }
+  validates_with EmailDomainValidator
   has_secure_password
   validates :password, presence: true, length: { minimum: 6 }, allow_nil: true
 

--- a/app/validators/email_domain_validator.rb
+++ b/app/validators/email_domain_validator.rb
@@ -1,0 +1,7 @@
+class EmailDomainValidator < ActiveModel::Validator
+  def validate(record)
+    if record.email.strip.end_with? '@j-scorer.com'
+      record.errors[:email] << "Can't be @j-scorer.com"
+    end
+  end
+end

--- a/app/views/games/_game_display.html.erb
+++ b/app/views/games/_game_display.html.erb
@@ -97,13 +97,13 @@
           <div class="contestant-result" id="third-result">
             Third place:
             <div class="btn-group" data-toggle="buttons">
-              <label id="p3right" class="btn btn-default fj-button">
+              <label id="p3right" class="btn btn-default fj-button fj-right">
                 <input type="radio" name="third_right" value=true /> Right
               </label>
-              <label id="p3wrong" class="btn btn-default fj-button">
+              <label id="p3wrong" class="btn btn-default fj-button fj-wrong">
                 <input type="radio" name="third_right" value=false /> Wrong
               </label>
-              <label id="p3dnp" class="btn btn-default fj-button">
+              <label id="p3dnp" class="btn btn-default fj-button fj-dnp">
                 <input type="radio" name="third_right" value=null /> N/A
               </label>
             </div>
@@ -112,13 +112,13 @@
           <div class="contestant-result" id="second-result">
             Second place:
             <div class="btn-group" data-toggle="buttons">
-              <label id="p2right" class="btn btn-default fj-button">
+              <label id="p2right" class="btn btn-default fj-button fj-right">
                 <input type="radio" name="second_right" value=true /> Right
               </label>
-              <label id="p2wrong" class="btn btn-default fj-button">
+              <label id="p2wrong" class="btn btn-default fj-button fj-wrong">
                 <input type="radio" name="second_right" value=false /> Wrong
               </label>
-              <label id="p2dnp" class="btn btn-default fj-button">
+              <label id="p2dnp" class="btn btn-default fj-button fj-dnp">
                 <input type="radio" name="second_right" value=null /> N/A
               </label>
             </div>
@@ -127,13 +127,13 @@
           <div class="contestant-result" id="first-result">
             First place:
             <div class="btn-group" data-toggle="buttons">
-              <label id="p1right" class="btn btn-default fj-button">
+              <label id="p1right" class="btn btn-default fj-button fj-right">
                 <input type="radio" name="first_right" value=true /> Right
               </label>
-              <label id="p1wrong" class="btn btn-default fj-button">
+              <label id="p1wrong" class="btn btn-default fj-button fj-wrong">
                 <input type="radio" name="first_right" value=false /> Wrong
               </label>
-              <label id="p1dnp" class="btn btn-default fj-button">
+              <label id="p1dnp" class="btn btn-default fj-button fj-dnp">
                 <input type="radio" name="first_right" value=null /> N/A
               </label>
             </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,10 @@
 
       <div>
         <% flash.each do |message_type, message| %>
-          <%= content_tag(:div, message, class: "alert alert-#{message_type}") %>
+          <div class="alert alert-<%= message_type %> alert-dismissible" role="alert">
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <%= message %>
+          </div>
         <% end %>
       </div>
 

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -10,10 +10,10 @@
 
       <%= hidden_field_tag :email, @user.email %>
 
-      <%= f.label :password %>
+      <%= f.label :password, 'Choose a new password' %>
       <%= f.password_field :password, class: 'form-control' %>
 
-      <%= f.label :password_confirmation, 'Confirm password' %>
+      <%= f.label :password_confirmation, 'Confirm new password' %>
       <%= f.password_field :password_confirmation, class: 'form-control' %>
       <br />
 

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,8 +1,9 @@
 <% if object.errors.any? %>
   <div id='error_explanation'>
-    <div class='alert alert-danger'>
-      The form contains <%= pluralize(object.errors.count, 'error') %>.
+    <div>
+      The form contains <%= pluralize(object.errors.count, 'error') %>:
     </div>
+    <br />
     <ul>
       <% object.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -13,6 +13,18 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     assert_select 'div.field_with_errors'
   end
 
+  test 'illegal j-scorer email address' do
+    get signup_path
+    assert_no_difference 'User.count' do
+      post users_path, user: { email: 'someone@j-scorer.com',
+                               password: 'password',
+                               password_confirmation: 'password' }
+    end
+    assert_template 'users/new'
+    assert_select 'div#error_explanation'
+    assert_select 'div.field_with_errors'
+  end
+
   test 'valid signup information' do
     get signup_path
     assert_difference 'User.count', 1 do


### PR DESCRIPTION
The rundown:
- Add coloration to checks and Xes and contestant Final results for easier visual distinction.
- When a user revisits a clue, highlight the currently-selected result.
- Make Bootstrap alerts dismissible.
- Ban users from having @j-scorer.com emails.
- Improve the verbiage on the password resets edit page.
