### PR TITLE
Bump puma to 4.3.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
     parser (2.6.5.0)
       ast (~> 2.4.0)
     pg (0.21.0)
-    puma (4.3.2)
+    puma (4.3.3)
       nio4r (~> 2.0)
     rack (2.0.8)
     rack-test (1.1.0)


### PR DESCRIPTION
4.3.1 has a security vulnerability, and 4.3.2 introduced a header bug
that prevented user logins from sticking. Both of these issues appear
to be fixed in 4.3.3.