### PR TITLE
Paginate stats-page games table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,4 +78,6 @@ gem 'default_value_for', '~> 3.3.0'
 # Allow for convenient(-ish) customization of the data displayed
 # by "render :json".
 gem 'active_model_serializers', '~> 0.10.10'
+
+gem 'pagy', '~> 3.8'
 # rubocop:enable FileName

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,7 @@ GEM
     nio4r (2.5.3)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    pagy (3.8.3)
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
@@ -242,6 +243,7 @@ DEPENDENCIES
   mini_backtrace
   minitest-reporters
   momentjs-rails (>= 2.9.0)
+  pagy (~> 3.8)
   pg (~> 0.15)
   puma
   rack-timeout

--- a/app/assets/javascripts/stats.js.erb
+++ b/app/assets/javascripts/stats.js.erb
@@ -206,7 +206,7 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
     }
   }
 
-  var sortOrder = new Map();
+  var sortOrder = new Map( [["pa", 1]] );
   var defaultSortDirections =  {
     "pa": 1,  // "Played at", descending
     "rr": 1,  // "Rerun?", descending (check then dash)
@@ -222,9 +222,6 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
 
   function sortOrderString() {
     var result = "&sort_order=";
-    if ( sortOrder.size === 0 ) {
-      return result + "pa1";
-    }
     sortOrder.forEach(function (dir, abbr, _map) {
       result += (abbr + dir + ",");
     });
@@ -235,7 +232,18 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
   function gamesTableHeaderSetup() {
     $( "#played-at-col, #rerun-col, #show-date-col, #play-type-col, " +
         "#coryat-col, #round-one-col, #round-two-col, #dds-right-col, " +
-        "#dds-wrong-col, #final-col" ).on( "click", function( event ) {
+        "#dds-wrong-col, #final-col" ).each( function() {
+      switch ( sortOrder.get($( this ).data( "abbr" ))) {
+        case 0:
+          $( this ).addClass( "tablesorter-header tablesorter-headerAsc");
+          break;
+        case 1:
+          $( this ).addClass( "tablesorter-header tablesorter-headerDesc");
+          break;
+        default:
+          $( this ).addClass( "tablesorter-header tablesorter-headerUnSorted");
+      }
+    }).on( "click", function( event ) {
       var abbr = $( this ).data( "abbr" );
       if ( event.shiftKey ) {
         // Shift-click: create a compound sort.

--- a/app/assets/javascripts/stats.js.erb
+++ b/app/assets/javascripts/stats.js.erb
@@ -211,7 +211,7 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
     "pa": 1,  // "Played at", descending
     "rr": 1,  // "Rerun?", descending (check then dash)
     "sd": 1,  // "Show date", descending
-    "pt": 0,  // "Play type", ascending
+    "pt": 0,  // "Play type", ascending (alphabetical)
     "cs": 1,  // "Coryat score", descending
     "ro": 1,  // "Round one", descending
     "rt": 1,  // "Round two", descending
@@ -290,7 +290,6 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
     }
     var url = "/" + statsPageType + sharedName + "/games?page=" + currentPage
         + queryString + allGames + sortOrderString();
-    console.log( "Making request to " + url );
 
     $.ajax({
       url: url,
@@ -325,26 +324,6 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
       $sharingForm = $( "#sharing-form" ),
       $sharingSettingsError = $( "#sharing-settings-error" ),
       $sharedStatsNameField = $( "#user_shared_stats_name" );
-
-  // Remove these before Tablesorter can get its grubby mitts on them.
-//  var $untracked = $( "tr.untracked" ).detach();
-
-  // Make "Games" table sortable. Initialize default sort to
-  // [ leftmost column, descending ]. Prevent meaningless attempts
-  // to sort by "Actions" column (currently in position 9).
-  // To prevent a JS error, skip this if the table is empty.
-//  if ( !$gameTable.hasClass( 'empty' ) ) {
-//    $gameTable.tablesorter({
-//      sortList: [[0,1]],
-//      sortInitialOrder: "desc",
-//      headers: {
-//        1: { sortInitialOrder: "asc" },  // Rerun status (check or -)
-//        3: { sortInitialOrder: "asc" },  // Play type (text)
-//        9: { sortInitialOrder: "asc" },  // Final (check or X)
-//        10: { sorter: false }            // Actions
-//      }
-//    });
-//  }
 
   $gameTable.stickyTableHeaders({
     scrollableArea: $( '#stats-area' )
@@ -385,24 +364,19 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
   });
 
   $( "#show-all-games" ).on( "click", function() {
-//    $untracked.appendTo( "#gameTable tbody" );
-//    $untracked = null;
     $( "#some-hidden" ).hide();
     $( "#all-shown" ).show();
     document.getElementById( "games" ).dataset.showingall = "true";
     currentPage = 1;
     makeGamesRequest();
-//    $gameTable.trigger( "update", true );
   });
 
   $( "#hide-untracked-games" ).on( "click", function() {
-//    $untracked = $( "tr.untracked" ).detach();
     $( "#all-shown" ).hide();
     $( "#some-hidden" ).show();
     document.getElementById( "games" ).dataset.showingall = "false";
     currentPage = 1;
     makeGamesRequest();
-//    $gameTable.trigger( "update", true );
   });
 
   $( ".update-user-filters" ).on( "click", function() {

--- a/app/assets/javascripts/stats.js.erb
+++ b/app/assets/javascripts/stats.js.erb
@@ -206,9 +206,10 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
     }
   }
 
+  var sortOrder = new Map();
   var defaultSortDirections =  {
     "pa": 1,  // "Played at", descending
-    "rr": 1,  // "Rerun?", descending
+    "rr": 1,  // "Rerun?", descending (check then dash)
     "sd": 1,  // "Show date", descending
     "pt": 0,  // "Play type", ascending
     "cs": 1,  // "Coryat score", descending
@@ -216,9 +217,9 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
     "rt": 1,  // "Round two", descending
     "dr": 1,  // "DDs right", descending
     "dw": 1,  // "DDs wrong", descending
-    "fi": 0   // "Final", ascending
+    "fi": 1   // "Final", descending (check then X)
   };
-  var sortOrder = new Map();
+
   function sortOrderString() {
     var result = "&sort_order=";
     sortOrder.forEach( function( dir, abbr, _map ) {

--- a/app/assets/javascripts/stats.js.erb
+++ b/app/assets/javascripts/stats.js.erb
@@ -209,6 +209,7 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
   function makeGamesRequest( page ) {
     var sharedName = "";
     var allGames = "";
+    var queryString = "";
     var data = document.getElementById( "games" ).dataset;
     if ( statsPageType === "shared" ) {
       sharedName = "/" + data.name;
@@ -219,8 +220,11 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
     if ( data.showingall === "true" ) {
       allGames = "&allgames=true";
     }
+    if ( data.querystring ) {
+      queryString = "&" + data.querystring;
+    }
     var url = "/" + statsPageType + sharedName + "/games?page=" + page
-        + "&" + data.querystring + allGames;
+        + queryString + allGames;
 
     $.ajax({
       url: url,

--- a/app/assets/javascripts/stats.js.erb
+++ b/app/assets/javascripts/stats.js.erb
@@ -209,16 +209,18 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
   function makeGamesRequest( page ) {
     var sharedName = "";
     var allGames = "";
+    var data = document.getElementById( "games" ).dataset;
     if ( statsPageType === "shared" ) {
-      sharedName = "/" + document.getElementById( "games" ).dataset.name;
+      sharedName = "/" + data.name;
     } else if ( statsPageType !== "stats" && statsPageType !== "sample" ) {
       alert( "Error: malformed link" );
       return false;
     }
-    if ( document.getElementById( "games" ).dataset.showingall === "true" ) {
+    if ( data.showingall === "true" ) {
       allGames = "&allgames=true";
     }
-    var url = "/" + statsPageType + sharedName + "/games?page=" + page + allGames;
+    var url = "/" + statsPageType + sharedName + "/games?page=" + page
+        + "&" + data.querystring + allGames;
 
     $.ajax({
       url: url,

--- a/app/assets/javascripts/stats.js.erb
+++ b/app/assets/javascripts/stats.js.erb
@@ -195,6 +195,24 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
     }
   }
 
+  function makeGamesRequest( page ) {
+    $.ajax({
+      url: "/stats/games?page=" + page,
+      method: "GET",
+      success: function( data ) {
+        $( "#games-container" ).html( data );
+        pagyLinkSetup();
+      }
+    });
+  }
+
+  function pagyLinkSetup() {
+    $( ".pagy-link " ).on( "click", function() {
+      makeGamesRequest(this.href.split("#games_").slice(-1)[0]);
+      return false;
+    });
+  }
+
   $( "#stats-area" ).tabs();
 
   var $gameTable = $( "#gameTable" ),
@@ -413,9 +431,5 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
   $( "#stats-loading-message" ).remove();
   $( "#stats-area" ).show();
 
-  $.ajax({
-    url: "/stats/games",
-    method: "GET",
-    success: function( data ) { $( "#games-container" ).html( data ); }
-  });
+  makeGamesRequest( 1 );
 });

--- a/app/assets/javascripts/stats.js.erb
+++ b/app/assets/javascripts/stats.js.erb
@@ -87,6 +87,17 @@ $( ".stats-topic, .stats-sample_topic, .stats-shared_topic" )
 
 $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
 
+  var statsPageType;
+  if ( $( this ).hasClass( "stats-show" ) ) {
+    statsPageType = "stats";
+  } else if ( $( this ).hasClass ( "stats-sample" ) ) {
+    statsPageType = "sample";
+  } else if ( $( this ).hasClass ( "stats-shared" ) ) {
+    statsPageType = "shared";
+  } else {
+    alert ( "Invalid request" );
+  }
+
   // Returns an array of play type abbreviations corresponding
   // to the checked boxes on the play types tab, or ['none']
   // if no boxes are checked.
@@ -196,8 +207,21 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
   }
 
   function makeGamesRequest( page ) {
+    var sharedName = "";
+    var allGames = "";
+    if ( statsPageType === "shared" ) {
+      sharedName = "/" + document.getElementById( "games" ).dataset.name;
+    } else if ( statsPageType !== "stats" && statsPageType !== "sample" ) {
+      alert( "Error: malformed link" );
+      return false;
+    }
+    if ( document.getElementById( "games" ).dataset.showingall === "true" ) {
+      allGames = "&allgames=true";
+    }
+    var url = "/" + statsPageType + sharedName + "/games?page=" + page + allGames;
+
     $.ajax({
-      url: "/stats/games?page=" + page,
+      url: url,
       method: "GET",
       success: function( data ) {
         $( "#games-container" ).html( data );
@@ -207,8 +231,9 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
   }
 
   function pagyLinkSetup() {
-    $( ".pagy-link " ).on( "click", function() {
-      makeGamesRequest(this.href.split("#games_").slice(-1)[0]);
+    $( ".page-link " ).on( "click", function() {
+      var pagyPageNumber = this.href.split( "#games_" ).slice(-1)[0];
+      makeGamesRequest( pagyPageNumber );
       return false;
     });
   }
@@ -286,18 +311,22 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
   });
 
   $( "#show-all-games" ).on( "click", function() {
-    $untracked.appendTo( "#gameTable tbody" );
-    $untracked = null;
+//    $untracked.appendTo( "#gameTable tbody" );
+//    $untracked = null;
     $( "#some-hidden" ).hide();
     $( "#all-shown" ).show();
-    $gameTable.trigger( "update", true );
+    document.getElementById( "games" ).dataset.showingall = "true";
+    makeGamesRequest( 1 );
+//    $gameTable.trigger( "update", true );
   });
 
   $( "#hide-untracked-games" ).on( "click", function() {
-    $untracked = $( "tr.untracked" ).detach();
+//    $untracked = $( "tr.untracked" ).detach();
     $( "#all-shown" ).hide();
     $( "#some-hidden" ).show();
-    $gameTable.trigger( "update", true );
+    document.getElementById( "games" ).dataset.showingall = "false";
+    makeGamesRequest( 1 );
+//    $gameTable.trigger( "update", true );
   });
 
   $( ".update-user-filters" ).on( "click", function() {

--- a/app/assets/javascripts/stats.js.erb
+++ b/app/assets/javascripts/stats.js.erb
@@ -222,10 +222,13 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
 
   function sortOrderString() {
     var result = "&sort_order=";
-    sortOrder.forEach( function( dir, abbr, _map ) {
-      result += ( abbr + dir + "," );
+    if ( sortOrder.size === 0 ) {
+      return result + "pa1";
+    }
+    sortOrder.forEach(function (dir, abbr, _map) {
+      result += (abbr + dir + ",");
     });
-    return ( result.length > 12 ? result.slice( 0, -1 ) : "" );
+    return result.slice( 0, -1 );
   }
   var currentPage = 1;
 

--- a/app/assets/javascripts/stats.js.erb
+++ b/app/assets/javascripts/stats.js.erb
@@ -232,6 +232,7 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
       success: function( data ) {
         $( "#games-container" ).html( data );
         pagyLinkSetup();
+        gamesTableHeaderSetup();
       }
     });
   }
@@ -243,6 +244,16 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
       return false;
     });
   }
+
+  function gamesTableHeaderSetup() {
+    $( "#played-at-col, #rerun-col, #show-date-col, #play-type-col, #coryat-col, " +
+        "#round-one-col, #round-two-col, #dds-right-col, #dds-wrong-col, #final-col" ).on(
+            "click", function() {
+                alert( "Clicked on " + $( this ).data( "abbr" ) );
+        }
+    );
+  }
+
 
   $( "#stats-area" ).tabs();
 

--- a/app/assets/javascripts/stats.js.erb
+++ b/app/assets/javascripts/stats.js.erb
@@ -206,7 +206,60 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
     }
   }
 
-  function makeGamesRequest( page ) {
+  var defaultSortDirections =  {
+    "pa": 1,  // "Played at", descending
+    "rr": 1,  // "Rerun?", descending
+    "sd": 1,  // "Show date", descending
+    "pt": 0,  // "Play type", ascending
+    "cs": 1,  // "Coryat score", descending
+    "ro": 1,  // "Round one", descending
+    "rt": 1,  // "Round two", descending
+    "dr": 1,  // "DDs right", descending
+    "dw": 1,  // "DDs wrong", descending
+    "fi": 0   // "Final", ascending
+  };
+  var sortOrder = new Map();
+  function sortOrderString() {
+    var result = "&sort_order=";
+    sortOrder.forEach( function( dir, abbr, _map ) {
+      result += ( abbr + dir + "," );
+    });
+    return ( result.length > 12 ? result.slice( 0, -1 ) : "" );
+  }
+  var currentPage = 1;
+
+  function gamesTableHeaderSetup() {
+    $( "#played-at-col, #rerun-col, #show-date-col, #play-type-col, " +
+        "#coryat-col, #round-one-col, #round-two-col, #dds-right-col, " +
+        "#dds-wrong-col, #final-col" ).on( "click", function( event ) {
+      var abbr = $( this ).data( "abbr" );
+      if ( event.shiftKey ) {
+        // Shift-click: create a compound sort.
+        // If the order exists in the list, reverse its direction.
+        // (This will maintain its position in the ordering.)
+        // Otherwise, add it to the end with its default direction.
+        if ( sortOrder.has( abbr ) ) {
+          sortOrder.set( abbr, 1 - sortOrder.get( abbr ) );
+        } else {
+          sortOrder.set( abbr, defaultSortDirections[abbr] );
+        }
+      } else {
+        // Standard click: replace the existing sort.
+        // If the column is currently sorted, reverse its direction.
+        var sortDirection;
+        if ( sortOrder.has ( abbr ) ) {
+          sortDirection = 1 - sortOrder.get( abbr );
+        } else {
+          sortDirection = defaultSortDirections[abbr];
+        }
+        sortOrder.clear();
+        sortOrder.set( abbr, sortDirection );
+      }
+      makeGamesRequest();
+    });
+  }
+
+  function makeGamesRequest() {
     var sharedName = "";
     var allGames = "";
     var queryString = "";
@@ -223,8 +276,9 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
     if ( data.querystring ) {
       queryString = "&" + data.querystring;
     }
-    var url = "/" + statsPageType + sharedName + "/games?page=" + page
-        + queryString + allGames;
+    var url = "/" + statsPageType + sharedName + "/games?page=" + currentPage
+        + queryString + allGames + sortOrderString();
+    console.log( "Making request to " + url );
 
     $.ajax({
       url: url,
@@ -239,34 +293,11 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
 
   function pagyLinkSetup() {
     $( ".page-link " ).on( "click", function() {
-      var pagyPageNumber = this.href.split( "#games_" ).slice(-1)[0];
-      makeGamesRequest( pagyPageNumber );
+      currentPage = this.href.split( "#games_" ).slice(-1)[0];
+      makeGamesRequest();
       return false;
     });
   }
-
-  function gamesTableHeaderSetup() {
-    $( "#played-at-col, #rerun-col, #show-date-col, #play-type-col, " +
-       "#coryat-col, #round-one-col, #round-two-col, #dds-right-col, " +
-       "#dds-wrong-col, #final-col" ).on( "click", function() {
-         var abbr = $( this ).data( "abbr" );
-          alert( "Clicked on " + abbr + ". " +
-              "Its default sort is " + defaultSortDirections[abbr] + "." );
-        });
-  }
-
-  var defaultSortDirections =  {
-    "pa": 1,
-    "rr": 1,
-    "sd": 1,
-    "pt": 0,
-    "cs": 1,
-    "ro": 1,
-    "rt": 1,
-    "dr": 1,
-    "dw": 1,
-    "fi": 0
-  };
 
 
   $( "#stats-area" ).tabs();
@@ -347,7 +378,8 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
     $( "#some-hidden" ).hide();
     $( "#all-shown" ).show();
     document.getElementById( "games" ).dataset.showingall = "true";
-    makeGamesRequest( 1 );
+    currentPage = 1;
+    makeGamesRequest();
 //    $gameTable.trigger( "update", true );
   });
 
@@ -356,7 +388,8 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
     $( "#all-shown" ).hide();
     $( "#some-hidden" ).show();
     document.getElementById( "games" ).dataset.showingall = "false";
-    makeGamesRequest( 1 );
+    currentPage = 1;
+    makeGamesRequest();
 //    $gameTable.trigger( "update", true );
   });
 
@@ -491,5 +524,5 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
   $( "#stats-loading-message" ).remove();
   $( "#stats-area" ).show();
 
-  makeGamesRequest( 1 );
+  makeGamesRequest();
 });

--- a/app/assets/javascripts/stats.js.erb
+++ b/app/assets/javascripts/stats.js.erb
@@ -246,13 +246,27 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
   }
 
   function gamesTableHeaderSetup() {
-    $( "#played-at-col, #rerun-col, #show-date-col, #play-type-col, #coryat-col, " +
-        "#round-one-col, #round-two-col, #dds-right-col, #dds-wrong-col, #final-col" ).on(
-            "click", function() {
-                alert( "Clicked on " + $( this ).data( "abbr" ) );
-        }
-    );
+    $( "#played-at-col, #rerun-col, #show-date-col, #play-type-col, " +
+       "#coryat-col, #round-one-col, #round-two-col, #dds-right-col, " +
+       "#dds-wrong-col, #final-col" ).on( "click", function() {
+         var abbr = $( this ).data( "abbr" );
+          alert( "Clicked on " + abbr + ". " +
+              "Its default sort is " + defaultSortDirections[abbr] + "." );
+        });
   }
+
+  var defaultSortDirections =  {
+    "pa": 1,
+    "rr": 1,
+    "sd": 1,
+    "pt": 0,
+    "cs": 1,
+    "ro": 1,
+    "rt": 1,
+    "dr": 1,
+    "dw": 1,
+    "fi": 0
+  };
 
 
   $( "#stats-area" ).tabs();

--- a/app/assets/javascripts/stats.js.erb
+++ b/app/assets/javascripts/stats.js.erb
@@ -210,24 +210,24 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
       $sharedStatsNameField = $( "#user_shared_stats_name" );
 
   // Remove these before Tablesorter can get its grubby mitts on them.
-  var $untracked = $( "tr.untracked" ).detach();
+//  var $untracked = $( "tr.untracked" ).detach();
 
   // Make "Games" table sortable. Initialize default sort to
   // [ leftmost column, descending ]. Prevent meaningless attempts
   // to sort by "Actions" column (currently in position 9).
   // To prevent a JS error, skip this if the table is empty.
-  if ( !$gameTable.hasClass( 'empty' ) ) {
-    $gameTable.tablesorter({
-      sortList: [[0,1]],
-      sortInitialOrder: "desc",
-      headers: {
-        1: { sortInitialOrder: "asc" },  // Rerun status (check or -)
-        3: { sortInitialOrder: "asc" },  // Play type (text)
-        9: { sortInitialOrder: "asc" },  // Final (check or X)
-        10: { sorter: false }            // Actions
-      }
-    });
-  }
+//  if ( !$gameTable.hasClass( 'empty' ) ) {
+//    $gameTable.tablesorter({
+//      sortList: [[0,1]],
+//      sortInitialOrder: "desc",
+//      headers: {
+//        1: { sortInitialOrder: "asc" },  // Rerun status (check or -)
+//        3: { sortInitialOrder: "asc" },  // Play type (text)
+//        9: { sortInitialOrder: "asc" },  // Final (check or X)
+//        10: { sorter: false }            // Actions
+//      }
+//    });
+//  }
 
   $gameTable.stickyTableHeaders({
     scrollableArea: $( '#stats-area' )
@@ -412,4 +412,10 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
 
   $( "#stats-loading-message" ).remove();
   $( "#stats-area" ).show();
+
+  $.ajax({
+    url: "/stats/games",
+    method: "GET",
+    success: function( data ) { $( "#games-container" ).html( data ); }
+  });
 });

--- a/app/assets/stylesheets/master.css.scss
+++ b/app/assets/stylesheets/master.css.scss
@@ -421,6 +421,11 @@ input {
     justify-content: center;
     align-items: center;
   }
+
+  .pagination .page.active {
+    background-color: $j-blue;
+    color: $j-yellow;
+  }
 }
 
 /* topic-stats page (e.g., /stats/topic/PotentPotables) */
@@ -502,11 +507,6 @@ html.no-js #stats-loading-message {
     &:hover {
       color: $j-lighter-blue;
     }
-  }
-
-  .pagination .page.active {
-    background-color: $j-blue;
-    color: $j-yellow;
   }
 
   .spacer {

--- a/app/assets/stylesheets/master.css.scss
+++ b/app/assets/stylesheets/master.css.scss
@@ -504,6 +504,11 @@ html.no-js #stats-loading-message {
     }
   }
 
+  .pagination .page.active {
+    background-color: $j-blue;
+    color: $j-yellow;
+  }
+
   .spacer {
     margin-top: 5vh;
     margin-bottom: 5vh;

--- a/app/assets/stylesheets/master.css.scss
+++ b/app/assets/stylesheets/master.css.scss
@@ -413,6 +413,14 @@ input {
       color: black;
     }
   }
+
+  .pagy-selector {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
 }
 
 /* topic-stats page (e.g., /stats/topic/PotentPotables) */

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -171,6 +171,6 @@ class StatsController < ApplicationController
   end
 
   def set_games
-    @games = @user.games
+    @pagy, @games = pagy(@user.games)
   end
 end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -40,7 +40,7 @@ class StatsController < ApplicationController
 
     set_play_types
     set_filters
-    set_games
+    set_games('stats')
 
     render layout: false
   end
@@ -50,7 +50,9 @@ class StatsController < ApplicationController
 
     set_play_types
     set_filters
-    set_games
+    set_games('sample')
+
+    render 'games', layout: false
   end
 
   def shared_games
@@ -58,7 +60,9 @@ class StatsController < ApplicationController
 
     set_play_types
     set_filters
-    set_games
+    set_games('shared')
+
+    render 'games', layout: false
   end
 
   def topic
@@ -170,7 +174,17 @@ class StatsController < ApplicationController
     @categories = @user.topic_details(@topic, @play_types, filter_sql)
   end
 
-  def set_games
-    @pagy, @games = pagy(@user.games)
+  def set_games(stats_page_type)
+    dataset = if params[:allgames] == 'true'
+                @user.games
+              else
+                filter_sql = User.filter_sql(@filters, '')
+                play_type_sql = ' AND play_type IN '\
+                    "(#{@play_types.map { |x| "'#{x}'" }.join(', ')})"
+                @user.games.where("TRUE#{play_type_sql}#{filter_sql}")
+              end
+    page_link_html = "class=\"page-link\" data-pagetype=\"#{stats_page_type}\""
+
+    @pagy, @games = pagy(dataset, link_extra: page_link_html)
   end
 end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,7 +1,9 @@
 class StatsController < ApplicationController
+  include Pagy::Backend
+
   before_action :logged_in_user, only: %i[show topic]
-  before_action :find_shared_stats_user, only: %i[shared shared_topic]
-  before_action :set_sample_user, only: %i[sample sample_topic]
+  before_action :find_shared_stats_user, only: %i[shared shared_topic shared_games]
+  before_action :set_sample_user, only: %i[sample sample_topic sample_games]
 
   def show
     @user = current_user
@@ -28,6 +30,30 @@ class StatsController < ApplicationController
     set_filters
     set_stats_vars
     render 'show'
+  end
+
+  # TODO: Have: user, user_name, sample, shared, play_types, filters
+  # TODO: Need: conversion to SQL
+  def games
+    @user = current_user
+    @user_name = @user.email
+
+    set_play_types
+    set_filters
+  end
+
+  def sample_games
+    @sample = true
+
+    set_play_types
+    set_filters
+  end
+
+  def shared_games
+    @shared = true
+
+    set_play_types
+    set_filters
   end
 
   def topic

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -32,8 +32,6 @@ class StatsController < ApplicationController
     render 'show'
   end
 
-  # TODO: Have: user, user_name, sample, shared, play_types, filters
-  # TODO: Need: conversion to SQL
   def games
     @user = current_user
     @user_name = @user.email

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -40,6 +40,9 @@ class StatsController < ApplicationController
 
     set_play_types
     set_filters
+    set_games
+
+    render layout: false
   end
 
   def sample_games
@@ -47,6 +50,7 @@ class StatsController < ApplicationController
 
     set_play_types
     set_filters
+    set_games
   end
 
   def shared_games
@@ -54,6 +58,7 @@ class StatsController < ApplicationController
 
     set_play_types
     set_filters
+    set_games
   end
 
   def topic
@@ -163,5 +168,9 @@ class StatsController < ApplicationController
   def set_topics
     filter_sql = User.filter_sql(@filters)
     @categories = @user.topic_details(@topic, @play_types, filter_sql)
+  end
+
+  def set_games
+    @games = @user.games
   end
 end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -175,15 +175,7 @@ class StatsController < ApplicationController
   end
 
   def set_games(stats_page_type)
-    dataset = if params[:allgames] == 'true'
-                @user.games
-              else
-                filter_sql = User.filter_sql(@filters, '')
-                play_type_sql = ' AND play_type IN '\
-                    "(#{@play_types.map { |x| "'#{x}'" }.join(', ')})"
-                @user.games.where("TRUE#{play_type_sql}#{filter_sql}")
-              end.select('*, round_one_score + 2 * round_two_score AS score')
-              .unscope(:order).order('score DESC')
+    dataset = @user.games_for(params, @filters, @play_types)
     page_link_html = "class=\"page-link\" data-pagetype=\"#{stats_page_type}\""
 
     @pagy, @games = pagy(dataset, link_extra: page_link_html)

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -182,7 +182,8 @@ class StatsController < ApplicationController
                 play_type_sql = ' AND play_type IN '\
                     "(#{@play_types.map { |x| "'#{x}'" }.join(', ')})"
                 @user.games.where("TRUE#{play_type_sql}#{filter_sql}")
-              end
+              end.select('*, round_one_score + 2 * round_two_score AS score')
+              .unscope(:order).order('score DESC')
     page_link_html = "class=\"page-link\" data-pagetype=\"#{stats_page_type}\""
 
     @pagy, @games = pagy(dataset, link_extra: page_link_html)

--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -1,0 +1,7 @@
+module StatsHelper
+  include Pagy::Frontend
+
+  def pagy_url_for(page, pagy)
+    "#{stats_url}#games_#{page}"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,8 +79,8 @@ class User < ApplicationRecord
     games.find_by(game_id: game_id).present?
   end
 
-  def self.filter_sql(filters)
-    FilterSQLGenerator.new(filters).sql
+  def self.filter_sql(filters, table_prefix = 'g.')
+    FilterSQLGenerator.new(filters, table_prefix).sql
   end
 
   # rubocop:disable MemoizedInstanceVariableName

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -111,9 +111,13 @@ class User < ApplicationRecord
   def play_type_summary(filters)
     @pts ||= PlayTypeSummary.new(self, filters).stats
   end
+  # rubocop:enable MemoizedInstanceVariableName
 
   def topic_details(topic, play_types, filters)
     TopicDetails.new(topic, play_types, filters).stats
   end
-  # rubocop:enable MemoizedInstanceVariableName
+
+  def games_for(params, filters, play_types)
+    FilteredUserGames.new(self, params, filters, play_types).games
+  end
 end

--- a/app/stats/filtered_user_games.rb
+++ b/app/stats/filtered_user_games.rb
@@ -1,0 +1,43 @@
+class FilteredUserGames
+  attr_reader :games
+
+  # TODO: Flesh this out into actual code.
+  # TODO: Use the temp score-ordering code as an example.
+  # pa: date_played
+  # rr: rerun
+  # sd: show_date
+  # pt: play_type
+  # TODO: cs: round_one_score + 2 * round_two_score
+  # ro: round_one_score
+  # rt: round_two_score
+  # TODO: dr: CASE WHEN dd1_result = 7 THEN 1 ELSE 0 END +
+  #                     dd2a_result
+  #                     dd2b_result
+  # TODO: dw: CASE WHEN dd1_result IN (5, 6) THEN 1 ELSE 0 END +
+  #                     dd2a_result
+  #                     dd2b_result
+  # fi: final_result
+  #
+  def initialize(user, params, filters, play_types)
+    @filters = filters
+    @play_types = play_types
+
+    @games = user.games
+    filter_games unless params[:allgames] == 'true'
+    order_games
+  end
+
+  private
+
+  def filter_games
+    filter_sql = User.filter_sql(@filters, '')
+    play_type_sql = 'play_type IN '\
+                 "(#{@play_types.map { |x| "'#{x}'" }.join(', ')})"
+    @games = @games.where("#{play_type_sql}#{filter_sql}")
+  end
+
+  def order_games
+    @games = @games.select('*, round_one_score + 2 * round_two_score AS score')
+                   .unscope(:order).order('score DESC')
+  end
+end

--- a/app/stats/filtered_user_games.rb
+++ b/app/stats/filtered_user_games.rb
@@ -1,23 +1,33 @@
 class FilteredUserGames
   attr_reader :games
 
-  # TODO: Flesh this out into actual code.
-  # TODO: Use the temp score-ordering code as an example.
-  # pa: date_played
-  # rr: rerun
-  # sd: show_date
-  # pt: play_type
-  # TODO: cs: round_one_score + 2 * round_two_score
-  # ro: round_one_score
-  # rt: round_two_score
-  # TODO: dr: CASE WHEN dd1_result = 7 THEN 1 ELSE 0 END +
-  #                     dd2a_result
-  #                     dd2b_result
-  # TODO: dw: CASE WHEN dd1_result IN (5, 6) THEN 1 ELSE 0 END +
-  #                     dd2a_result
-  #                     dd2b_result
-  # fi: final_result
-  #
+  COLUMN_NAMES = {
+    'pa' => 'date_played',
+    'rr' => 'rerun',
+    'sd' => 'show_date',
+    'pt' => 'play_type',
+    'cs' => 'coryat',
+    'ro' => 'round_one_score',
+    'rt' => 'round_two_score',
+    'dr' => 'dd_right',
+    'dw' => 'dd_wrong',
+    'fi' => 'final_result'
+  }.freeze
+
+  def dd_counter(condition, column_name)
+    "
+    CASE WHEN dd1_result #{condition} THEN 1 ELSE 0 END +
+    CASE WHEN dd2a_result #{condition} THEN 1 ELSE 0 END +
+    CASE WHEN dd2b_result #{condition} THEN 1 ELSE 0 END AS #{column_name}
+    "
+  end
+
+  NONCE_COLUMNS = {
+    'cs' => 'round_one_score + 2 * round_two_score AS coryat',
+    'dr' => dd_counter('= 7', 'dd_right'),
+    'dw' => dd_counter('IN (5, 6)', 'dd_wrong')
+  }.freeze
+
   def initialize(user, params, filters, play_types)
     @filters = filters
     @play_types = play_types

--- a/app/views/stats/_games.html.erb
+++ b/app/views/stats/_games.html.erb
@@ -1,4 +1,4 @@
-<div id="games">
+<div id="games" data-name=<%= @user.shared_stats_name %>>
   <h2 id="games-headline">
     Games played by <%= @user_name %>
     <% if tracked == user_games_count %>

--- a/app/views/stats/_games.html.erb
+++ b/app/views/stats/_games.html.erb
@@ -16,8 +16,8 @@
     <% end %>
   </h2>
 
-  <!-- This is filled with the games table via a request that uses
-       games.html.erb (without the underscore). -->
+  <%# This is filled with the games table via a request that uses
+      games.html.erb (without the underscore). %>
   <div id="games-container">
   </div>
 

--- a/app/views/stats/_games.html.erb
+++ b/app/views/stats/_games.html.erb
@@ -16,66 +16,11 @@
     <% end %>
   </h2>
 
+  <!-- This is filled with the games table via a request that uses
+       games.html.erb (without the underscore). -->
   <div id="games-container">
   </div>
 
-  <!--
-  <table id="gameTable" class="tablesorter tablesorter-blue<%= ' empty' if user_games_count.zero? %>">
-    <thead>
-      <tr>
-        <th>Played at</th>
-        <th>Rerun?</th>
-        <th>Show date</th>
-        <th>Play type</th>
-        <th>Coryat score</th>
-        <th>Round one</th>
-        <th>Round two</th>
-        <th>DDs right</th>
-        <th>DDs wrong</th>
-        <th>Final</th>
-        <th colspan=2>Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @user.games.each do |game| %>
-        <tr class="<%= game.play_type %><%= ' untracked' unless @summary[:all][:game_ids].include?(game.id) %>">
-          <td><%= game.date_played.in_time_zone.to_s if game.date_played.year > 0 %></td>
-          <td><%= game.rerun ? '✓' : '-' %></td>
-          <td><%= game.show_date %></td>
-          <td><%= PLAY_TYPES[game.play_type] %></td>
-          <% if game.round_one_score.present? && game.final.present? %>
-            <td><%= number_to_currency(game.adjusted_game_score, precision: 0) %></td>
-            <td><%= number_to_currency(game.adjusted_round_one_score, precision: 0) %></td>
-            <td><%= number_to_currency(game.adjusted_round_two_score, precision: 0) %></td>
-            <td><%= game.dds_right %></td>
-            <td><%= game.dds_wrong %></td>
-            <td><%= game.final_symbol %></td>
-          <% else %>
-            <td colspan="6" style="text-align: center;">
-              Missing data -
-              <a href="#" data-toggle="modal" data-target="#bad-data-modal">
-                more information here
-              </a>
-            </td>
-          <% end %>
-          <% if current_user?(game.user) %>
-            <td><%= link_to 'edit', game_path(g: game.game_id) %></td>
-            <td><%= link_to 'delete',
-                            delete_path(game),
-                            method: :delete,
-                            data: { confirm: 'Are you sure you want to ' +
-                                             'delete game ' +
-                                             game.game_id.to_s +
-                                             '?' } %></td>
-          <% else %>
-            <td class="disabled">edit</td>
-            <td class="disabled">delete</td>
-          <% end %>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-  -->
 
   <!-- Invalid-game-data modal -->
   <div id="bad-data-modal" class="modal fade" tabindex="-1" role="dialog"

--- a/app/views/stats/_games.html.erb
+++ b/app/views/stats/_games.html.erb
@@ -15,6 +15,10 @@
     <% end %>
   </h2>
 
+  <div id="games-container">
+  </div>
+
+  <!--
   <table id="gameTable" class="tablesorter tablesorter-blue<%= ' empty' if user_games_count.zero? %>">
     <thead>
       <tr>
@@ -70,6 +74,7 @@
       <% end %>
     </tbody>
   </table>
+  -->
 
   <!-- Invalid-game-data modal -->
   <div id="bad-data-modal" class="modal fade" tabindex="-1" role="dialog"

--- a/app/views/stats/_games.html.erb
+++ b/app/views/stats/_games.html.erb
@@ -1,4 +1,5 @@
-<div id="games" data-name=<%= @user.shared_stats_name %>>
+<div id="games" data-name=<%= @user.shared_stats_name %>
+                data-querystring=<%= URI.parse(request.original_url).query %>>
   <h2 id="games-headline">
     Games played by <%= @user_name %>
     <% if tracked == user_games_count %>

--- a/app/views/stats/games.html.erb
+++ b/app/views/stats/games.html.erb
@@ -53,3 +53,9 @@
   <% end %>
   </tbody>
 </table>
+
+<div class="pagy-selector">
+  <%== pagy_nav(@pagy) %>
+</div>
+
+<%= @pagy.inspect %>

--- a/app/views/stats/games.html.erb
+++ b/app/views/stats/games.html.erb
@@ -55,7 +55,7 @@
 </table>
 
 <div class="pagy-selector">
-  <%== pagy_nav(@pagy) %>
+  <%== pagy_nav(@pagy) if @pagy.pages > 1 %>
 </div>
 
 <%= @pagy.inspect %>

--- a/app/views/stats/games.html.erb
+++ b/app/views/stats/games.html.erb
@@ -1,16 +1,16 @@
 <table id="gameTable" class="tablesorter tablesorter-blue">
   <thead>
   <tr>
-    <th>Played at</th>
-    <th>Rerun?</th>
-    <th>Show date</th>
-    <th>Play type</th>
-    <th>Coryat score</th>
-    <th>Round one</th>
-    <th>Round two</th>
-    <th>DDs right</th>
-    <th>DDs wrong</th>
-    <th>Final</th>
+    <th id="played-at-col" data-abbr="pa">Played at</th>
+    <th id="rerun-col" data-abbr="rr">Rerun?</th>
+    <th id="show-date-col" data-abbr="sd">Show date</th>
+    <th id="play-type-col" data-abbr="pt">Play type</th>
+    <th id="coryat-col" data-abbr="cs">Coryat score</th>
+    <th id="round-one-col" data-abbr="ro">Round one</th>
+    <th id="round-two-col" data-abbr="rt">Round two</th>
+    <th id="dds-right-col" data-abbr="dr">DDs right</th>
+    <th id="dds-wrong-col" data-abbr="dw">DDs wrong</th>
+    <th id="final-col" data-abbr="fi">Final</th>
     <th colspan=2>Actions</th>
   </tr>
   </thead>

--- a/app/views/stats/games.html.erb
+++ b/app/views/stats/games.html.erb
@@ -57,5 +57,3 @@
 <div class="pagy-selector">
   <%== pagy_nav(@pagy) if @pagy.pages > 1 %>
 </div>
-
-<%= @pagy.inspect %>

--- a/app/views/stats/games.html.erb
+++ b/app/views/stats/games.html.erb
@@ -1,0 +1,55 @@
+<table id="gameTable" class="tablesorter tablesorter-blue">
+  <thead>
+  <tr>
+    <th>Played at</th>
+    <th>Rerun?</th>
+    <th>Show date</th>
+    <th>Play type</th>
+    <th>Coryat score</th>
+    <th>Round one</th>
+    <th>Round two</th>
+    <th>DDs right</th>
+    <th>DDs wrong</th>
+    <th>Final</th>
+    <th colspan=2>Actions</th>
+  </tr>
+  </thead>
+  <tbody>
+  <% @games.each do |game| %>
+    <tr class="<%= game.play_type %>">
+      <td><%= game.date_played.in_time_zone.to_s if game.date_played.year > 0 %></td>
+      <td><%= game.rerun ? '✓' : '-' %></td>
+      <td><%= game.show_date %></td>
+      <td><%= PLAY_TYPES[game.play_type] %></td>
+      <% if game.round_one_score.present? && game.final.present? %>
+        <td><%= number_to_currency(game.adjusted_game_score, precision: 0) %></td>
+        <td><%= number_to_currency(game.adjusted_round_one_score, precision: 0) %></td>
+        <td><%= number_to_currency(game.adjusted_round_two_score, precision: 0) %></td>
+        <td><%= game.dds_right %></td>
+        <td><%= game.dds_wrong %></td>
+        <td><%= game.final_symbol %></td>
+      <% else %>
+        <td colspan="6" style="text-align: center;">
+          Missing data -
+          <a href="#" data-toggle="modal" data-target="#bad-data-modal">
+            more information here
+          </a>
+        </td>
+      <% end %>
+      <% if current_user?(game.user) %>
+        <td><%= link_to 'edit', game_path(g: game.game_id) %></td>
+        <td><%= link_to 'delete',
+                        delete_path(game),
+                        method: :delete,
+                        data: { confirm: 'Are you sure you want to ' +
+                            'delete game ' +
+                            game.game_id.to_s +
+                            '?' } %></td>
+      <% else %>
+        <td class="disabled">edit</td>
+        <td class="disabled">delete</td>
+      <% end %>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -114,7 +114,7 @@ Pagy::VARS[:overflow] = :last_page
 # Instance variables
 # See https://ddnexus.github.io/pagy/api/pagy#instance-variables
 # Pagy::VARS[:items] = 20                                   # default
-Pagy::VARS[:items] = 2#5
+Pagy::VARS[:items] = 25
 
 
 # Other Variables

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,173 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+# Pagy initializer file (3.8.3)
+# Customize only what you really need and notice that Pagy works also without any of the following lines.
+# Should you just cherry pick part of this file, please maintain the require-order of the extras
+
+
+# Extras
+# See https://ddnexus.github.io/pagy/extras
+
+
+# Backend Extras
+
+# Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
+# See https://ddnexus.github.io/pagy/extras/array
+# require 'pagy/extras/array'
+
+# Countless extra: Paginate without any count, saving one query per rendering
+# See https://ddnexus.github.io/pagy/extras/countless
+# require 'pagy/extras/countless'
+# Pagy::VARS[:cycle] = false    # default
+
+# Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
+# See https://ddnexus.github.io/pagy/extras/elasticsearch_rails
+# require 'pagy/extras/elasticsearch_rails'
+
+# Searchkick extra: Paginate `Searchkick::Results` objects
+# See https://ddnexus.github.io/pagy/extras/searchkick
+# require 'pagy/extras/searchkick'
+
+
+# Frontend Extras
+
+# Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
+# See https://ddnexus.github.io/pagy/extras/bootstrap
+# require 'pagy/extras/bootstrap'
+
+# Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
+# See https://ddnexus.github.io/pagy/extras/bulma
+# require 'pagy/extras/bulma'
+
+# Foundation extra: Add nav, nav_js and combo_nav_js helpers and templates for Foundation pagination
+# See https://ddnexus.github.io/pagy/extras/foundation
+# require 'pagy/extras/foundation'
+
+# Materialize extra: Add nav, nav_js and combo_nav_js helpers for Materialize pagination
+# See https://ddnexus.github.io/pagy/extras/materialize
+# require 'pagy/extras/materialize'
+
+# Navs extra: Add nav_js and combo_nav_js javascript helpers
+# Notice: the other frontend extras add their own framework-styled versions,
+# so require this extra only if you need the unstyled version
+# See https://ddnexus.github.io/pagy/extras/navs
+# require 'pagy/extras/navs'
+
+# Semantic extra: Add nav, nav_js and combo_nav_js helpers for Semantic UI pagination
+# See https://ddnexus.github.io/pagy/extras/semantic
+# require 'pagy/extras/semantic'
+
+# UIkit extra: Add nav helper and templates for UIkit pagination
+# See https://ddnexus.github.io/pagy/extras/uikit
+# require 'pagy/extras/uikit'
+
+# Multi size var used by the *_nav_js helpers
+# See https://ddnexus.github.io/pagy/extras/navs#steps
+# Pagy::VARS[:steps] = { 0 => [2,3,3,2], 540 => [3,5,5,3], 720 => [5,7,7,5] }   # example
+
+
+# Feature Extras
+
+# Headers extra: http response headers (and other helpers) useful for API pagination
+# See http://ddnexus.github.io/pagy/extras/headers
+# require 'pagy/extras/headers'
+# Pagy::VARS[:headers] = { page: 'Current-Page', items: 'Page-Items', count: 'Total-Count', pages: 'Total-Pages' }     # default
+
+# Support extra: Extra support for features like: incremental, infinite, auto-scroll pagination
+# See https://ddnexus.github.io/pagy/extras/support
+# require 'pagy/extras/support'
+
+# Items extra: Allow the client to request a custom number of items per page with an optional selector UI
+# See https://ddnexus.github.io/pagy/extras/items
+require 'pagy/extras/items'
+# Pagy::VARS[:items_param] = :items    # default
+Pagy::VARS[:items_param] = :games
+Pagy::VARS[:max_items]   = 100       # default
+
+# Overflow extra: Allow for easy handling of overflowing pages
+# See https://ddnexus.github.io/pagy/extras/overflow
+require 'pagy/extras/overflow'
+# Pagy::VARS[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+Pagy::VARS[:overflow] = :last_page
+
+# Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
+# See https://ddnexus.github.io/pagy/extras/metadata
+# you must require the shared internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
+# require 'pagy/extras/shared'
+# require 'pagy/extras/metadata'
+# For performance reason, you should explicitly set ONLY the metadata you use in the frontend
+# Pagy::VARS[:metadata] = [:scaffold_url, :count, :page, :prev, :next, :last]    # example
+
+# Trim extra: Remove the page=1 param from links
+# See https://ddnexus.github.io/pagy/extras/trim
+require 'pagy/extras/trim'
+
+
+
+# Pagy Variables
+# See https://ddnexus.github.io/pagy/api/pagy#variables
+# All the Pagy::VARS are set for all the Pagy instances but can be overridden
+# per instance by just passing them to Pagy.new or the #pagy controller method
+
+
+# Instance variables
+# See https://ddnexus.github.io/pagy/api/pagy#instance-variables
+# Pagy::VARS[:items] = 20                                   # default
+Pagy::VARS[:items] = 25
+
+
+# Other Variables
+# See https://ddnexus.github.io/pagy/api/pagy#other-variables
+# Pagy::VARS[:size]       = [1,4,4,1]                       # default
+# Pagy::VARS[:page_param] = :page                           # default
+# Pagy::VARS[:params]     = {}                              # default
+# Pagy::VARS[:anchor]     = '#anchor'                       # example
+# Pagy::VARS[:link_extra] = 'data-remote="true"'            # example
+
+
+# Rails
+
+# Rails: extras assets path required by the helpers that use javascript
+# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_items_selector_js)
+# See https://ddnexus.github.io/pagy/extras#javascript
+# Rails.application.config.assets.paths << Pagy.root.join('javascripts')
+
+
+# I18n
+
+# Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
+# See https://ddnexus.github.io/pagy/api/frontend#i18n
+# Notice: No need to configure anything in this section if your app uses only "en"
+# or if you use the i18n extra below
+#
+# Examples:
+# load the "de" built-in locale:
+# Pagy::I18n.load(locale: 'de')
+#
+# load the "de" locale defined in the custom file at :filepath:
+# Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
+#
+# load the "de", "en" and "es" built-in locales:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({locale: 'de'},
+#                 {locale: 'en'},
+#                 {locale: 'es'})
+#
+# load the "en" built-in locale, a custom "es" locale,
+# and a totally custom locale complete with a custom :pluralize proc:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({locale: 'en'},
+#                 {locale: 'es', filepath: 'path/to/pagy-es.yml'},
+#                 {locale: 'xyz',  # not built-in
+#                  filepath: 'path/to/pagy-xyz.yml',
+#                  pluralize: lambda{|count| ... } )
+
+
+# I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
+# than the default pagy internal i18n (see above)
+# See https://ddnexus.github.io/pagy/extras/i18n
+# require 'pagy/extras/i18n'
+
+# Default i18n key
+# Pagy::VARS[:i18n_key] = 'pagy.item_name'   # default

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -101,7 +101,7 @@ Pagy::VARS[:overflow] = :last_page
 
 # Trim extra: Remove the page=1 param from links
 # See https://ddnexus.github.io/pagy/extras/trim
-require 'pagy/extras/trim'
+# require 'pagy/extras/trim'
 
 
 
@@ -114,7 +114,7 @@ require 'pagy/extras/trim'
 # Instance variables
 # See https://ddnexus.github.io/pagy/api/pagy#instance-variables
 # Pagy::VARS[:items] = 20                                   # default
-Pagy::VARS[:items] = 25
+Pagy::VARS[:items] = 2#5
 
 
 # Other Variables
@@ -124,6 +124,7 @@ Pagy::VARS[:items] = 25
 # Pagy::VARS[:params]     = {}                              # default
 # Pagy::VARS[:anchor]     = '#anchor'                       # example
 # Pagy::VARS[:link_extra] = 'data-remote="true"'            # example
+Pagy::VARS[:link_extra] = 'class="pagy-link"'
 
 
 # Rails

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,11 +16,6 @@ Rails.application.routes.draw do
   get 'sample/topic/:topic' => 'stats#sample_topic', as: :sample_topic
   get 'shared/:user/topic/:topic' => 'stats#shared_topic', as: :shared_topic
 
-  # TODO: Move these into the XHR section
-  get 'stats/games' => 'stats#games', as: :games
-  get 'sample/games' => 'stats#sample_games', as: :sample_games
-  get 'shared/:user/games' => 'stats#shared_games', as: :shared_games
-
   get 'login' => 'sessions#new'
   post 'login' => 'sessions#create'
   delete 'logout' => 'sessions#destroy'
@@ -45,5 +40,9 @@ Rails.application.routes.draw do
 
     patch 'filters' => 'users#update_user_filters'
     patch 'sharing' => 'users#update_sharing_status'
+
+    get 'stats/games' => 'stats#games', as: :games
+    get 'sample/games' => 'stats#sample_games', as: :sample_games
+    get 'shared/:user/games' => 'stats#shared_games', as: :shared_games
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,11 @@ Rails.application.routes.draw do
   get 'sample/topic/:topic' => 'stats#sample_topic', as: :sample_topic
   get 'shared/:user/topic/:topic' => 'stats#shared_topic', as: :shared_topic
 
+  # TODO: Move these into the XHR section
+  get 'stats/games' => 'stats#games', as: :games
+  get 'sample/games' => 'stats#sample_games', as: :sample_games
+  get 'shared/:user/games' => 'stats#shared_games', as: :shared_games
+
   get 'login' => 'sessions#new'
   post 'login' => 'sessions#create'
   delete 'logout' => 'sessions#destroy'

--- a/test/integration/users_stats_test.rb
+++ b/test/integration/users_stats_test.rb
@@ -12,6 +12,6 @@ class UsersStatsTest < ActionDispatch::IntegrationTest
     assert_select 'title', 'J! Scorer - Stats'
     assert_select 'h2'
     assert_match @user.games.count.to_s, response.body
-    assert_match '2005', response.body
+    assert_match 'bad-data-modal', response.body
   end
 end


### PR DESCRIPTION
Stats-page load times are becoming unacceptably long for users with 1000+ saved games. (This includes both the sample stats page and the most-frequently-accessed shared user stats page, the latter of which is taking so long it's occasionally timing out.)

A bit of digging showed that a large majority of the load time is spent on populating the games table with all of the user's games. Specifically, turning every single one of the user's games into a Ruby object and generating all of the values for its row.

My initial experimentation showed that load times can be decreased by about 90% if no more than 25 games are turned into objects and then rows.

The lightweight pagination gem Pagy does the bulk of the work here, with a couple caveats:

1) Because Pagy expects its new-page requests to result in the loading of an entirely new webpage in the browser, the code is customized to make an AJAX request and replace only the games table, not the whole stats page. Three new routes and controller actions are created to fulfill these requests for each of a) the user's own stats page, b) the sample stats page, and c) stats pages that have been shared by other users.

2) The pagination breaks the existing table-sorting mechanism (i.e., throwing all of the data and a JS table-sorting library at the user's browser and making the browser deal with it). As such, custom sorting code is also included here, both in JS to add sorting requirements to the new-page requests, and in Ruby to retrieve the games corresponding to those requirements.