### PR TITLE
Improve DD checkbox appearance in Firefox

### DIFF
--- a/app/assets/stylesheets/master.css.scss
+++ b/app/assets/stylesheets/master.css.scss
@@ -24,6 +24,8 @@ $check-light-green: #88ff88;
 $x-red: #ff0000;
 $x-light-red: #ff8888;
 
+$checkmark: '\2713';
+
 /* universal */
 
 *{
@@ -1038,13 +1040,37 @@ html.no-js #stats-loading-message {
             margin: 0;
           }
 
-          input {
+          // DD checkbox using a span (to fix Firefox checkbox sizing issue)
+          label.dd-checkbox input {
+              display: none;
+          }
+          label.dd-checkbox span {
+            display: inline-block;
             width: 5vh;
             height: 5vh;
+            background: $medium-background-color;
+            border: 0.3vw solid $dd-border;
             cursor: pointer;
-            /* TODO: Find a better fix for the tiny checkbox in Firefox */
-            /* -moz-appearance: none; */
-            margin: 0;
+            margin: 1.5vh;
+            position: relative;
+          }
+          label.dd-checkbox span:hover {
+            background: $j-light-blue;
+            border: 0.3vw solid $j-yellow;
+            width: 5vh;
+            height: 5vh;
+          }
+          label.dd-checkbox :checked + span {
+            background: $light-background-color;
+          }
+          label.dd-checkbox :checked + span:after {
+            content: $checkmark;
+            font-size: 4.5vh;
+            font-weight: bold;
+            color: $dark-background-color;
+            margin-left: 5px;
+            margin-top: -5px;
+            position: absolute;
           }
 
           button {

--- a/app/assets/stylesheets/master.css.scss
+++ b/app/assets/stylesheets/master.css.scss
@@ -1051,7 +1051,8 @@ html.no-js #stats-loading-message {
             background: $medium-background-color;
             border: 0.3vw solid $dd-border;
             cursor: pointer;
-            margin: 1.5vh;
+            margin-left: -1vh;
+            margin-bottom: 1vh;
             position: relative;
           }
           label.dd-checkbox span:hover {

--- a/app/views/games/_board_area.html.erb
+++ b/app/views/games/_board_area.html.erb
@@ -50,8 +50,10 @@
 
       <div id="dd-nr-cancel">
         <div id="dd-checkbox-container">
-          <label for="dd-checkbox">DD&nbsp;</label>
-          <input type="checkbox" id="dd-checkbox" value="DD" />
+          <label class="dd-checkbox" for="dd-checkbox">DD
+            <input type="checkbox" id="dd-checkbox" value="DD" />
+            <span></span>
+          </label>
         </div>
         <div id="button-nr">
           <button type="button">NR</button>


### PR DESCRIPTION
This change is only tested in Firefox 81.0.2 and Chrome version 86.0.4240.111 on Linux (Ubuntu 20.04).

I tried my best to make the appearance same in Firefox and Chrome, but in my testing, they are close but not identical. Other browsers/platforms may appear different. I am not a front-end developer, so my CSS skills are limited.  