### PR TITLE
Update settings for SendGrid

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,8 +73,8 @@ Rails.application.configure do
     address:              'smtp.sendgrid.net',
     port:                 '587',
     authentication:       :plain,
-    user_name:            ENV['SENDGRID_USERNAME'],
-    password:             ENV['SENDGRID_PASSWORD'],
+    user_name:            'apikey',
+    password:             ENV['SENDGRID_API_KEY'],
     domain:               ENV['MAILER_DOMAIN'],
     enable_starttls_auto: true
   }


### PR DESCRIPTION
SendGrid is now requiring authentication via API key instead of username and password.

Alter the config files to use the key from a new config variable, and switch the username accordingly.