### PR TITLE
Move backup and restore features to Active Job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,9 @@ gem 'default_value_for', '~> 3.3.0'
 # by "render :json".
 gem 'active_model_serializers', '~> 0.10.10'
 
-gem 'activejob-status', '~> 0.1.6'
 gem 'pagy', '~> 3.8'
+
+# Enable backup and restore operations to be backgrounded.
+gem 'activejob-status', '~> 0.1.6'
+gem 'remotipart', '~> 1.4.4'
 # rubocop:enable FileName

--- a/Gemfile
+++ b/Gemfile
@@ -79,5 +79,6 @@ gem 'default_value_for', '~> 3.3.0'
 # by "render :json".
 gem 'active_model_serializers', '~> 0.10.10'
 
+gem 'activejob-status', '~> 0.1.6'
 gem 'pagy', '~> 3.8'
 # rubocop:enable FileName

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,9 @@ GEM
     activejob (6.0.3.3)
       activesupport (= 6.0.3.3)
       globalid (>= 0.3.6)
+    activejob-status (0.1.6)
+      activejob (>= 4.2)
+      activesupport (>= 4.2)
     activemodel (6.0.3.3)
       activesupport (= 6.0.3.3)
     activerecord (6.0.3.3)
@@ -231,6 +234,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.10)
+  activejob-status (~> 0.1.6)
   bcrypt (~> 3.1.7)
   bootstrap-sass (~> 3.4.1)
   bootstrap3-datetimepicker-rails (= 4.17.37)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,7 @@ GEM
       ffi (~> 1.0)
     rdoc (6.2.1)
     regexp_parser (1.7.1)
+    remotipart (1.4.4)
     rexml (3.2.4)
     rubocop (0.90.0)
       parallel (~> 1.10)
@@ -254,6 +255,7 @@ DEPENDENCIES
   rails (~> 6.0.0)
   rails-controller-testing
   rake
+  remotipart (~> 1.4.4)
   rubocop
   sass-rails (~> 5.0)
   sdoc

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,7 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require jquery.remotipart
 //= require jquery-ui/widgets/tabs
 //= require jquery-ui/effects/effect-scale
 //= require jquery.tablesorter.min

--- a/app/assets/javascripts/stats.js.erb
+++ b/app/assets/javascripts/stats.js.erb
@@ -310,6 +310,60 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
     });
   }
 
+  function backupLinkSetup() {
+    $( "#backup-link" ).on( "click", function() {
+      // The makeBackupRequest function can't be passed directly because an
+      // unwanted argument would be passed to it.
+      makeBackupRequest();
+      return false;
+    } );
+  }
+
+  function makeBackupRequest( backupId ) {
+    $.ajax({
+      url: backupId ? "/backup/" + backupId : "/backup",
+      method: "GET",
+      cache: false,
+      success: function ( data, _textStatus, jqXHR ) {
+        var contentType = jqXHR.getResponseHeader("Content-Type");
+        var disposition = jqXHR.getResponseHeader("Content-Disposition");
+        if ( contentType.indexOf( "json" ) >= 0 ) {
+          // It's a JSON response. Grab the job ID and try again.
+          if ( data.games ) {
+            var timeEstimate = Math.ceil( data.games / 300 ) * 5;
+            $backupSentence.html(
+              "<strong>Generating backup file. This should take about " +
+              timeEstimate.toString() + " seconds.</strong>"
+            );
+          }
+          if ( data.status === "failed" ) {
+            alert( "Oops. Something went wrong. If this persists, please " +
+                "email <%= ENV['SUPPORT_ADDRESS'] %>." );
+          } else {
+            window.setTimeout( makeBackupRequest, 4500, backupId || data.job_id )
+          }
+        } else if ( disposition && disposition.indexOf( "attachment" ) >= 0 ) {
+          // It's the backup file. Download it.
+          var startIndex = disposition.indexOf( 'filename="' ) + 10;
+          var endIndex = disposition.indexOf( ".jscor", startIndex ) + 6;
+          var fileName = disposition.slice( startIndex, endIndex );
+          var link = document.getElementById( "invisible-download-link" );
+          var blob = new Blob( [data], { type: contentType } );
+          var blobUrl = window.URL.createObjectURL( blob );
+          link.href = blobUrl;
+          link.download = fileName;
+          link.click();
+          URL.revokeObjectURL( blobUrl );
+          $backupSentence.html( originalBackupSentenceHtml );
+          backupLinkSetup();
+        } else {
+          alert( "Oops. Something went wrong. If this persists, please " +
+                 "email <%= ENV['SUPPORT_ADDRESS'] %>." );
+        }
+      }
+    });
+  }
+
 
   $( "#stats-area" ).tabs();
 
@@ -323,7 +377,9 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
       storedToDates = { "show-date": undefined, "date-played": undefined },
       $sharingForm = $( "#sharing-form" ),
       $sharingSettingsError = $( "#sharing-settings-error" ),
-      $sharedStatsNameField = $( "#user_shared_stats_name" );
+      $sharedStatsNameField = $( "#user_shared_stats_name" ),
+      $backupSentence = $( "#backup-sentence" ),
+      originalBackupSentenceHtml = $backupSentence.html();
 
   $gameTable.stickyTableHeaders({
     scrollableArea: $( '#stats-area' )
@@ -506,6 +562,8 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
 
   updateFilterSentence( "show-date" );
   updateFilterSentence( "date-played" );
+
+  backupLinkSetup();
 
   $( "#stats-loading-message" ).remove();
   $( "#stats-area" ).show();

--- a/app/assets/javascripts/stats.js.erb
+++ b/app/assets/javascripts/stats.js.erb
@@ -343,7 +343,7 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
             backupLinkSetup();
           } else if ( data.status === "failed" ) {
             alert( "Oops. Something went wrong. If this persists, please " +
-                "email <%= ENV['SUPPORT_ADDRESS'] %>." );
+                   "email <%= ENV['SUPPORT_ADDRESS'] %>." );
           } else {
             window.setTimeout( makeBackupRequest, 2000, backupId || data.job_id )
           }
@@ -368,7 +368,7 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
       },
       failure: function () {
         alert( "Oops. Something went wrong. If this persists, please " +
-            "email <%= ENV['SUPPORT_ADDRESS'] %>." );
+               "email <%= ENV['SUPPORT_ADDRESS'] %>." );
       }
     });
   }
@@ -388,7 +388,20 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
       $sharingSettingsError = $( "#sharing-settings-error" ),
       $sharedStatsNameField = $( "#user_shared_stats_name" ),
       $backupSentence = $( "#backup-sentence" ),
-      originalBackupSentenceHtml = $backupSentence.html();
+      originalBackupSentenceHtml = $backupSentence.html(),
+      $restoreForm = $( "#restore-form" );
+
+//  $( "#restore-submit-button" ).on( "click", function() {
+//    if ( !$( this ).hasClass( "disabled" ) ) {
+//      console.log("Successed with ajax!");
+//      $(this).addClass("disabled");
+//    }
+//    return false;
+//  });
+
+  $restoreForm.on( "ajax:success", function() {
+    console.log("successed out teh AJAX!");
+  });
 
   $gameTable.stickyTableHeaders({
     scrollableArea: $( '#stats-area' )

--- a/app/assets/javascripts/stats.js.erb
+++ b/app/assets/javascripts/stats.js.erb
@@ -341,7 +341,7 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
           alert( "Oops. Something went wrong. If this persists, please " +
                  "email <%= ENV['SUPPORT_ADDRESS'] %>." );
         } else {
-          window.setTimeout( makeBackupRequest, 2000, backupId || data.job_id )
+          window.setTimeout( makeBackupRequest, 1000, backupId || data.job_id )
         }
       },
       failure: function () {

--- a/app/assets/javascripts/stats.js.erb
+++ b/app/assets/javascripts/stats.js.erb
@@ -312,8 +312,6 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
 
   function backupLinkSetup() {
     $( "#backup-link" ).on( "click", function() {
-      // The makeBackupRequest function can't be passed directly because an
-      // unwanted argument would be passed to it.
       makeBackupRequest();
       return false;
     } );
@@ -324,11 +322,12 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
       url: backupId ? "/backup/" + backupId : "/backup",
       method: "GET",
       cache: false,
-      success: function ( data, _textStatus, jqXHR ) {
-        var contentType = jqXHR.getResponseHeader("Content-Type");
-        var disposition = jqXHR.getResponseHeader("Content-Disposition");
-        if ( contentType.indexOf( "json" ) >= 0 ) {
-          // It's a JSON response. Grab the job ID and try again.
+      timeout: 5000,  // milliseconds
+      success: function ( data, textStatus, jqXHR ) {
+//        var contentType = jqXHR.getResponseHeader("Content-Type");
+//        var disposition = jqXHR.getResponseHeader("Content-Disposition");
+//        if ( contentType.indexOf( "json" ) >= 0 ) {
+//          // It's a JSON response. Grab the job ID and try again.
           if ( data.games ) {
             var timeEstimate = Math.ceil( data.games / 300 ) * 5;
             $backupSentence.html(
@@ -336,30 +335,40 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
               timeEstimate.toString() + " seconds.</strong>"
             );
           }
-          if ( data.status === "failed" ) {
+          if ( data.status === "completed" ) {
+            var link = document.getElementById( "invisible-download-link" );
+            link.href = "/backup/" + backupId + "/download";
+            link.click();
+            $backupSentence.html( originalBackupSentenceHtml );
+            backupLinkSetup();
+          } else if ( data.status === "failed" ) {
             alert( "Oops. Something went wrong. If this persists, please " +
                 "email <%= ENV['SUPPORT_ADDRESS'] %>." );
           } else {
-            window.setTimeout( makeBackupRequest, 4500, backupId || data.job_id )
+            window.setTimeout( makeBackupRequest, 2000, backupId || data.job_id )
           }
-        } else if ( disposition && disposition.indexOf( "attachment" ) >= 0 ) {
-          // It's the backup file. Download it.
-          var startIndex = disposition.indexOf( 'filename="' ) + 10;
-          var endIndex = disposition.indexOf( ".jscor", startIndex ) + 6;
-          var fileName = disposition.slice( startIndex, endIndex );
-          var link = document.getElementById( "invisible-download-link" );
-          var blob = new Blob( [data], { type: contentType } );
-          var blobUrl = window.URL.createObjectURL( blob );
-          link.href = blobUrl;
-          link.download = fileName;
-          link.click();
-          URL.revokeObjectURL( blobUrl );
-          $backupSentence.html( originalBackupSentenceHtml );
-          backupLinkSetup();
-        } else {
-          alert( "Oops. Something went wrong. If this persists, please " +
-                 "email <%= ENV['SUPPORT_ADDRESS'] %>." );
-        }
+//        } else if ( disposition && disposition.indexOf( "attachment" ) >= 0 ) {
+//          // It's the backup file. Download it.
+//          var startIndex = disposition.indexOf( 'filename="' ) + 10;
+//          var endIndex = disposition.indexOf( ".jscor", startIndex ) + 6;
+//          var fileName = disposition.slice( startIndex, endIndex );
+//          var link = document.getElementById( "invisible-download-link" );
+//          var blob = new Blob( [data], { type: contentType } );
+//          var blobUrl = window.URL.createObjectURL( blob );
+//          link.href = blobUrl;
+//          link.download = fileName;
+//          link.click();
+//          URL.revokeObjectURL( blobUrl );
+//          $backupSentence.html( originalBackupSentenceHtml );
+//          backupLinkSetup();
+//        } else {
+//          alert( "Oops. Something went wrong. If this persists, please " +
+//                 "email <%= ENV['SUPPORT_ADDRESS'] %>." );
+//        }
+      },
+      failure: function () {
+        alert( "Oops. Something went wrong. If this persists, please " +
+            "email <%= ENV['SUPPORT_ADDRESS'] %>." );
       }
     });
   }

--- a/app/assets/javascripts/stats.js.erb
+++ b/app/assets/javascripts/stats.js.erb
@@ -323,48 +323,26 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
       method: "GET",
       cache: false,
       timeout: 5000,  // milliseconds
-      success: function ( data, textStatus, jqXHR ) {
-//        var contentType = jqXHR.getResponseHeader("Content-Type");
-//        var disposition = jqXHR.getResponseHeader("Content-Disposition");
-//        if ( contentType.indexOf( "json" ) >= 0 ) {
-//          // It's a JSON response. Grab the job ID and try again.
-          if ( data.games ) {
-            var timeEstimate = Math.ceil( data.games / 300 ) * 5;
-            $backupSentence.html(
-              "<strong>Generating backup file. This should take about " +
-              timeEstimate.toString() + " seconds.</strong>"
-            );
-          }
-          if ( data.status === "completed" ) {
-            var link = document.getElementById( "invisible-download-link" );
-            link.href = "/backup/" + backupId + "/download";
-            link.click();
-            $backupSentence.html( originalBackupSentenceHtml );
-            backupLinkSetup();
-          } else if ( data.status === "failed" ) {
-            alert( "Oops. Something went wrong. If this persists, please " +
-                   "email <%= ENV['SUPPORT_ADDRESS'] %>." );
-          } else {
-            window.setTimeout( makeBackupRequest, 2000, backupId || data.job_id )
-          }
-//        } else if ( disposition && disposition.indexOf( "attachment" ) >= 0 ) {
-//          // It's the backup file. Download it.
-//          var startIndex = disposition.indexOf( 'filename="' ) + 10;
-//          var endIndex = disposition.indexOf( ".jscor", startIndex ) + 6;
-//          var fileName = disposition.slice( startIndex, endIndex );
-//          var link = document.getElementById( "invisible-download-link" );
-//          var blob = new Blob( [data], { type: contentType } );
-//          var blobUrl = window.URL.createObjectURL( blob );
-//          link.href = blobUrl;
-//          link.download = fileName;
-//          link.click();
-//          URL.revokeObjectURL( blobUrl );
-//          $backupSentence.html( originalBackupSentenceHtml );
-//          backupLinkSetup();
-//        } else {
-//          alert( "Oops. Something went wrong. If this persists, please " +
-//                 "email <%= ENV['SUPPORT_ADDRESS'] %>." );
-//        }
+      success: function ( data ) {
+        if ( data.games ) {
+          var timeEstimate = Math.ceil( data.games / 300 ) * 5;
+          $backupSentence.html(
+            "<strong>Generating backup file. This should take about " +
+            timeEstimate.toString() + " seconds.</strong>"
+          );
+        }
+        if ( data.status === "completed" ) {
+          var link = document.getElementById( "invisible-download-link" );
+          link.href = "/backup/" + backupId + "/download";
+          link.click();
+          $backupSentence.html( originalBackupSentenceHtml );
+          backupLinkSetup();
+        } else if ( data.status === "failed" ) {
+          alert( "Oops. Something went wrong. If this persists, please " +
+                 "email <%= ENV['SUPPORT_ADDRESS'] %>." );
+        } else {
+          window.setTimeout( makeBackupRequest, 2000, backupId || data.job_id )
+        }
       },
       failure: function () {
         alert( "Oops. Something went wrong. If this persists, please " +
@@ -391,23 +369,12 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
       originalBackupSentenceHtml = $backupSentence.html(),
       $restoreForm = $( "#restore-form" );
 
-//  $( "#restore-submit-button" ).on( "click", function() {
-//    if ( !$( this ).hasClass( "disabled" ) ) {
-//      console.log("Successed with ajax!");
-//      $(this).addClass("disabled");
-//    }
-//    return false;
-//  });
-
-  $restoreForm.on( "ajax:success", function() {
-    console.log("successed out teh AJAX!");
-  });
 
   $gameTable.stickyTableHeaders({
     scrollableArea: $( '#stats-area' )
   });
 
-  // Similar for the "Topics" table.
+  // Sort the "Topics" table.
   // Default sort: [ topic name, ascending ].
   // Make everything else sort descending on first click.
   $topicTable.tablesorter({
@@ -422,7 +389,7 @@ $( ".stats-show, .stats-shared, .stats-sample" ).ready( function() {
     scrollableArea: $( '#stats-area' )
   });
 
-  // And similar for "Play types" table. Initialize default sort to
+  // Similar for "Play types" table. Initialize default sort to
   // [ Games played, descending ]. Prevent meaningless attempts
   // to sort by checkbox column (currently in position 0).
   // To prevent a JS error, skip this if the table is empty.

--- a/app/assets/stylesheets/master.css.scss
+++ b/app/assets/stylesheets/master.css.scss
@@ -855,7 +855,7 @@ html.no-js #stats-loading-message {
     }
 
     #restore-modal {
-      #restore-form {
+      #restore-form-group {
         width: 100%;
       }
 

--- a/app/controllers/backups_controller.rb
+++ b/app/controllers/backups_controller.rb
@@ -30,50 +30,71 @@ class BackupsController < ApplicationController
   end
 
   def restore
-    data = parse_file(params[:file])
+    games = parse_file(params[:file])
 
-    if data.present?
-      params[:user] = data
-    else
+    unless games.present?
       flash[:danger] = 'Could not parse file'
       redirect_to root_path and return
     end
 
-    if current_user.update(restore_params)
-      redirect_to stats_path
-    else
-      flash[:danger] = 'Could not restore data'
-      redirect_to root_path
-    end
+    job = RestoreFromBackupJob.perform_later(current_user, games)
+    @games_count = games.count
+    @job_id = job.job_id
+    respond_to { |format| format.js { render 'backups/restore' } }
+    # render json: { status: 'new', job_id: job.job_id,
+    #                progress: 0, total: games.size }
   end
+
+  def restore_progress
+    job_status = ActiveJob::Status.get(params[:restrore_id])
+    render json: job_status
+  end
+
+  # def restore
+  #   data = parse_file(params[:file])
+  #
+  #   if data.present?
+  #     params[:user] = data
+  #   else
+  #     flash[:danger] = 'Could not parse file'
+  #     redirect_to root_path and return
+  #   end
+  #
+  #   if current_user.update(restore_params)
+  #     redirect_to stats_path
+  #   else
+  #     flash[:danger] = 'Could not restore data'
+  #     redirect_to root_path
+  #   end
+  # end
 
   private
 
   # rubocop:disable all
-  def restore_params
-    params.require(:user)
-          .permit({ games_attributes: [:show_date,
-                                       :date_played,
-                                       :play_type,
-                                       :rerun,
-                                       :round_one_score,
-                                       :round_two_score,
-                                       :final_result,
-                                       { sixths_attributes: [:type,
-                                                             :board_position,
-                                                             :title,
-                                                             :topics_string,
-                                                             :result1,
-                                                             :result2,
-                                                             :result3,
-                                                             :result4,
-                                                             :result5] },
-                                       { final_attributes: [:category_title,
-                                                            :topics_string,
-                                                            :result,
-                                                            :third_right,
-                                                            :second_right,
-                                                            :first_right] }] })
-  end
+  # def restore_params
+  #   params.require(:user)
+  #         .permit({ games_attributes: [:show_date,
+  #                                      :date_played,
+  #                                      :play_type,
+  #                                      :rerun,
+  #                                      :round_one_score,
+  #                                      :round_two_score,
+  #                                      :final_result,
+  #                                      { sixths_attributes: [:type,
+  #                                                            :board_position,
+  #                                                            :title,
+  #                                                            :topics_string,
+  #                                                            :result1,
+  #                                                            :result2,
+  #                                                            :result3,
+  #                                                            :result4,
+  #                                                            :result5] },
+  #                                      { final_attributes: [:category_title,
+  #                                                           :topics_string,
+  #                                                           :result,
+  #                                                           :third_right,
+  #                                                           :second_right,
+  #                                                           :first_right] }] })
+  # end
   # rubocop: enable all
 end

--- a/app/controllers/backups_controller.rb
+++ b/app/controllers/backups_controller.rb
@@ -11,7 +11,7 @@ class BackupsController < ApplicationController
 
   def status
     job_status = ActiveJob::Status.get(params[:backup_id])
-    logger.warn { "About to return backup job status: #{job_status}" }
+    logger.info { "About to return backup job status: #{job_status}" }
     render json: job_status
   end
 
@@ -38,7 +38,7 @@ class BackupsController < ApplicationController
 
   def restore_progress
     job_status = ActiveJob::Status.get(params[:restore_id])
-    logger.warn { "About to return restore job status: #{job_status}" }
+    logger.info { "About to return restore job status: #{job_status}" }
     render json: job_status
   end
 end

--- a/app/controllers/backups_controller.rb
+++ b/app/controllers/backups_controller.rb
@@ -30,7 +30,7 @@ class BackupsController < ApplicationController
   end
 
   def restore
-    games = parse_file(params[:file])
+    games = parse_file(params[:backup_file])
 
     unless games.present?
       flash[:danger] = 'Could not parse file'
@@ -46,7 +46,7 @@ class BackupsController < ApplicationController
   end
 
   def restore_progress
-    job_status = ActiveJob::Status.get(params[:restrore_id])
+    job_status = ActiveJob::Status.get(params[:restore_id])
     render json: job_status
   end
 

--- a/app/controllers/backups_controller.rb
+++ b/app/controllers/backups_controller.rb
@@ -3,13 +3,6 @@ class BackupsController < ApplicationController
 
   before_action :dump_anonymous_user
 
-  # def new
-  #   s = ActiveModelSerializers::SerializableResource.new(current_user,
-  #                                                        include: '**')
-  #   send_data s.to_json,
-  #             filename: "backup#{Time.zone.now.strftime('%Y%m%d%H%M%S')}.jscor"
-  # end
-
   def new
     user = current_user
     job = CreateBackupJob.perform_later(user)
@@ -18,7 +11,7 @@ class BackupsController < ApplicationController
 
   def status
     job_status = ActiveJob::Status.get(params[:backup_id])
-    render json: job_status  # and return unless job_status.completed?
+    render json: job_status
   end
 
   def download
@@ -40,61 +33,10 @@ class BackupsController < ApplicationController
     job = RestoreFromBackupJob.perform_later(current_user, games)
     @games_count = games.count
     @job_id = job.job_id
-    respond_to { |format| format.js { render 'backups/restore' } }
-    # render json: { status: 'new', job_id: job.job_id,
-    #                progress: 0, total: games.size }
   end
 
   def restore_progress
     job_status = ActiveJob::Status.get(params[:restore_id])
     render json: job_status
   end
-
-  # def restore
-  #   data = parse_file(params[:file])
-  #
-  #   if data.present?
-  #     params[:user] = data
-  #   else
-  #     flash[:danger] = 'Could not parse file'
-  #     redirect_to root_path and return
-  #   end
-  #
-  #   if current_user.update(restore_params)
-  #     redirect_to stats_path
-  #   else
-  #     flash[:danger] = 'Could not restore data'
-  #     redirect_to root_path
-  #   end
-  # end
-
-  private
-
-  # rubocop:disable all
-  # def restore_params
-  #   params.require(:user)
-  #         .permit({ games_attributes: [:show_date,
-  #                                      :date_played,
-  #                                      :play_type,
-  #                                      :rerun,
-  #                                      :round_one_score,
-  #                                      :round_two_score,
-  #                                      :final_result,
-  #                                      { sixths_attributes: [:type,
-  #                                                            :board_position,
-  #                                                            :title,
-  #                                                            :topics_string,
-  #                                                            :result1,
-  #                                                            :result2,
-  #                                                            :result3,
-  #                                                            :result4,
-  #                                                            :result5] },
-  #                                      { final_attributes: [:category_title,
-  #                                                           :topics_string,
-  #                                                           :result,
-  #                                                           :third_right,
-  #                                                           :second_right,
-  #                                                           :first_right] }] })
-  # end
-  # rubocop: enable all
 end

--- a/app/controllers/backups_controller.rb
+++ b/app/controllers/backups_controller.rb
@@ -18,14 +18,15 @@ class BackupsController < ApplicationController
 
   def status
     job_status = ActiveJob::Status.get(params[:backup_id])
-    render json: job_status and return unless job_status.completed?
+    render json: job_status  # and return unless job_status.completed?
+  end
 
+  def download
     timestamp = Time.zone.now.strftime('%Y%m%d%H%M%S')
     server_filename = "/tmp/#{params[:backup_id]}"
     send_file server_filename,
               filename: "backup#{timestamp}.jscor",
               type: 'application/octet-stream'
-    # File.delete server_filename
   end
 
   def restore

--- a/app/controllers/backups_controller.rb
+++ b/app/controllers/backups_controller.rb
@@ -11,6 +11,7 @@ class BackupsController < ApplicationController
 
   def status
     job_status = ActiveJob::Status.get(params[:backup_id])
+    logger.warn { "About to return backup job status: #{job_status}" }
     render json: job_status
   end
 
@@ -37,6 +38,7 @@ class BackupsController < ApplicationController
 
   def restore_progress
     job_status = ActiveJob::Status.get(params[:restore_id])
+    logger.warn { "About to return restore job status: #{job_status}" }
     render json: job_status
   end
 end

--- a/app/helpers/backups_helper.rb
+++ b/app/helpers/backups_helper.rb
@@ -15,7 +15,6 @@ module BackupsHelper
     games = i[:games_attributes]
     return nil unless games.is_a?(Array)
     games.each { |game| return nil unless validate_game(game) }
-    # i
     games
   end
 

--- a/app/helpers/backups_helper.rb
+++ b/app/helpers/backups_helper.rb
@@ -15,7 +15,8 @@ module BackupsHelper
     games = i[:games_attributes]
     return nil unless games.is_a?(Array)
     games.each { |game| return nil unless validate_game(game) }
-    i
+    # i
+    games
   end
 
   def validate_game(game)

--- a/app/jobs/create_backup_job.rb
+++ b/app/jobs/create_backup_job.rb
@@ -1,0 +1,12 @@
+class CreateBackupJob < ApplicationJob
+  include ActiveJob::Status
+
+  def perform(user)
+    puts "user id is #{user.id}"
+    s = ActiveModelSerializers::SerializableResource.new(user, include: '**')
+    filename = "/tmp/#{job_id}"
+    File.open(filename, 'w') { |f| f.write s.to_json }
+
+    DeleteBackupJob.set(wait: 10.minutes).perform_later(filename)
+  end
+end

--- a/app/jobs/create_backup_job.rb
+++ b/app/jobs/create_backup_job.rb
@@ -2,7 +2,6 @@ class CreateBackupJob < ApplicationJob
   include ActiveJob::Status
 
   def perform(user)
-    puts "user id is #{user.id}"
     s = ActiveModelSerializers::SerializableResource.new(user, include: '**')
     filename = "/tmp/#{job_id}"
     File.open(filename, 'w') { |f| f.write s.to_json }

--- a/app/jobs/create_backup_job.rb
+++ b/app/jobs/create_backup_job.rb
@@ -7,6 +7,6 @@ class CreateBackupJob < ApplicationJob
     filename = "/tmp/#{job_id}"
     File.open(filename, 'w') { |f| f.write s.to_json }
 
-    DeleteBackupJob.set(wait: 10.minutes).perform_later(filename)
+    DeleteBackupJob.set(wait: 5.minutes).perform_later(filename)
   end
 end

--- a/app/jobs/delete_backup_job.rb
+++ b/app/jobs/delete_backup_job.rb
@@ -1,0 +1,5 @@
+class DeleteBackupJob < ApplicationJob
+  def perform(filename)
+    File.delete(filename) if File.exist?(filename)
+  end
+end

--- a/app/jobs/restore_from_backup_job.rb
+++ b/app/jobs/restore_from_backup_job.rb
@@ -1,8 +1,6 @@
 class RestoreFromBackupJob < ApplicationJob
   include ActiveJob::Status
 
-  @params = ActionController::Parameters.new
-
   def perform(user, games)
     progress.total = games.count
     games.each do |game|

--- a/app/jobs/restore_from_backup_job.rb
+++ b/app/jobs/restore_from_backup_job.rb
@@ -1,0 +1,52 @@
+class RestoreFromBackupJob < ApplicationJob
+  include ActiveJob::Status
+
+  @params = ActionController::Parameters.new
+
+  def perform(user, games)
+    progress.total = games.count
+    games.each do |game|
+      user.games.create!(parameterize_game(game))
+      progress.increment
+    end
+  end
+
+  private
+
+  def parameterize_game(game)
+    { show_date: game[:show_date],
+      date_played: game[:date_played],
+      play_type: game[:play_type],
+      rerun: game[:rerun],
+      round_one_score: game[:round_one_score],
+      round_two_score: game[:round_two_score],
+      final_result: game[:final_result],
+      sixths_attributes: parameterize_sixths(game[:sixths_attributes]),
+      final_attributes: parameterize_final(game[:final_attributes]) }
+  end
+
+  def parameterize_sixths(sixths)
+    result = []
+    sixths.each do |sixth|
+      result.append({ type: sixth[:type],
+                      board_position: sixth[:board_position],
+                      title: sixth[:title],
+                      topics_string: sixth[:topics_string],
+                      result1: sixth[:result1],
+                      result2: sixth[:result2],
+                      result3: sixth[:result3],
+                      result4: sixth[:result4],
+                      result5: sixth[:result5] })
+    end
+    result
+  end
+
+  def parameterize_final(final)
+    { category_title: final[:category_title],
+      topics_string: final[:topics_string],
+      result: final[:result],
+      first_right: final[:first_right],
+      second_right: final[:second_right],
+      third_right: final[:third_right] }
+  end
+end

--- a/app/views/backups/restore.js.erb
+++ b/app/views/backups/restore.js.erb
@@ -35,12 +35,12 @@ function makeRestoreStatusRequest() {
           emptyResponses = 0;
         } else {
           emptyResponses++;
-          if ( emptyResponses === 2 ) {
+          if ( emptyResponses === 4 ) {
             $modalContent.html(
                 $modalContent.html() +
                 '<div id="progress-update" class="col-xs-12 col-compact">Please wait...</div>'
             );
-          } else if ( emptyResponses === 4 ) {
+          } else if ( emptyResponses === 12 ) {
             $( "#progress-update" ).html( "Still working..." );
           }
         }

--- a/app/views/backups/restore.js.erb
+++ b/app/views/backups/restore.js.erb
@@ -26,7 +26,9 @@ function makeRestoreStatusRequest() {
         alert("Oops. Something went wrong. If this persists, please " +
             "email <%= ENV['SUPPORT_ADDRESS'] %>.");
       } else {
-        updateModalContent( data.progress, data.total );
+        if ( data.progress && data.total ) {
+          updateModalContent( data.progress, data.total );
+        }
         if ( data.status === "completed" ) {
           $modal.on( "hide.bs.modal", function () {
             window.location.reload();

--- a/app/views/backups/restore.js.erb
+++ b/app/views/backups/restore.js.erb
@@ -1,6 +1,10 @@
 var $modal = $( "#restore-modal" ),
     $modalContent = $( "#restore-modal-body" ),
-    $submitButton = $( "#restore-submit-button" );
+    $submitButton = $( "#restore-submit-button" ),
+    // Sometimes Heroku dynos don't find the job and return an empty JSON
+    // response. If this happens repeatedly, display a message to manage
+    // the user's (understandable) impatience/confusion.
+    emptyResponses = 0;
 
 function updateModalContent( completed, total ) {
   var statusMessage;
@@ -16,11 +20,6 @@ function updateModalContent( completed, total ) {
 }
 
 function makeRestoreStatusRequest() {
-  // Sometimes Heroku dynos don't find the job and return an empty JSON
-  // response. If this happens repeatedly, display a message to manage
-  // the user's (understandable) impatience/confusion.
-  var emptyResponses = 0;
-
   $.ajax({
     url: "/restore/<%= @job_id %>",
     method: "GET",
@@ -40,7 +39,7 @@ function makeRestoreStatusRequest() {
             $modalContent.html(
                 $modalContent.html() +
                 '<div id="progress-update" class="col-xs-12 col-compact">Please wait...</div>'
-            )
+            );
           } else if ( emptyResponses === 4 ) {
             $( "#progress-update" ).html( "Still working..." );
           }

--- a/app/views/backups/restore.js.erb
+++ b/app/views/backups/restore.js.erb
@@ -1,0 +1,34 @@
+var $modalContent = $( "#restore-modal-content" );
+
+function updateModalContent( completed, total ) {
+  $modalContent.html(
+    '<div class="col-xs-12 col-compact">' +
+    '  Restore in progress: ' + completed + ' of ' + total + ' games saved.' +
+    '</div>'
+  );
+}
+
+function makeRestoreStatusRequest() {
+  $.ajax({
+    url: "/restore/<%= @job_id %>",
+    method: "GET",
+    cache: false,
+    timeout: 5000,  // milliseconds
+    success: function ( data ) {
+      if ( data.status === "failed" ) {
+        alert( "Oops. Something went wrong. If this persists, please " +
+               "email <%= ENV['SUPPORT_ADDRESS'] %>." );
+      } else if ( data.status !== "completed" ) {
+        updateModalContent( data.progress, data.total );
+        window.setTimeout( makeRestoreStatusRequest, 1000 );
+      }
+    },
+    failure: function () {
+      alert( "Oops. Something went wrong. If this persists, please " +
+             "email <%= ENV['SUPPORT_ADDRESS'] %>." );
+    }
+  });
+}
+
+updateModalContent( 0, <%= @games_count %> )
+makeRestoreStatusRequest();

--- a/app/views/backups/restore.js.erb
+++ b/app/views/backups/restore.js.erb
@@ -1,4 +1,6 @@
-var $modalContent = $( "#restore-modal-content" );
+var $modal = $( "#restore-modal" ),
+    $modalContent = $( "#restore-modal-body" ),
+    $submitButton = $( "#restore-submit-button" );
 
 function updateModalContent( completed, total ) {
   var statusMessage;
@@ -25,8 +27,12 @@ function makeRestoreStatusRequest() {
             "email <%= ENV['SUPPORT_ADDRESS'] %>.");
       } else {
         updateModalContent( data.progress, data.total );
-        if ( data.status !== "completed" ) {
-          window.setTimeout(makeRestoreStatusRequest, 1000);
+        if ( data.status === "completed" ) {
+          $modal.on( "hide.bs.modal", function () {
+            window.location.reload();
+          });
+        } else {
+            window.setTimeout(makeRestoreStatusRequest, 1000);
         }
       }
     },
@@ -37,5 +43,6 @@ function makeRestoreStatusRequest() {
   });
 }
 
+$submitButton.hide();
 updateModalContent( 0, <%= @games_count %> )
 makeRestoreStatusRequest();

--- a/app/views/backups/restore.js.erb
+++ b/app/views/backups/restore.js.erb
@@ -16,6 +16,11 @@ function updateModalContent( completed, total ) {
 }
 
 function makeRestoreStatusRequest() {
+  // Sometimes Heroku dynos don't find the job and return an empty JSON
+  // response. If this happens repeatedly, display a message to manage
+  // the user's (understandable) impatience/confusion.
+  var emptyResponses = 0;
+
   $.ajax({
     url: "/restore/<%= @job_id %>",
     method: "GET",
@@ -28,6 +33,17 @@ function makeRestoreStatusRequest() {
       } else {
         if ( data.progress && data.total ) {
           updateModalContent( data.progress, data.total );
+          emptyResponses = 0;
+        } else {
+          emptyResponses++;
+          if ( emptyResponses === 2 ) {
+            $modalContent.html(
+                $modalContent.html() +
+                '<div id="progress-update" class="col-xs-12 col-compact">Please wait...</div>'
+            )
+          } else if ( emptyResponses === 4 ) {
+            $( "#progress-update" ).html( "Still working..." );
+          }
         }
         if ( data.status === "completed" ) {
           $modal.on( "hide.bs.modal", function () {

--- a/app/views/backups/restore.js.erb
+++ b/app/views/backups/restore.js.erb
@@ -1,10 +1,15 @@
 var $modalContent = $( "#restore-modal-content" );
 
 function updateModalContent( completed, total ) {
+  var statusMessage;
+  if (completed === total) {
+    statusMessage = "Complete! " + completed + " games restored.";
+  } else {
+    statusMessage = "Restore in progress: " + completed + " of " +
+                    total + " games saved.";
+  }
   $modalContent.html(
-    '<div class="col-xs-12 col-compact">' +
-    '  Restore in progress: ' + completed + ' of ' + total + ' games saved.' +
-    '</div>'
+    '<div class="col-xs-12 col-compact">' + statusMessage + '</div>'
   );
 }
 
@@ -16,11 +21,13 @@ function makeRestoreStatusRequest() {
     timeout: 5000,  // milliseconds
     success: function ( data ) {
       if ( data.status === "failed" ) {
-        alert( "Oops. Something went wrong. If this persists, please " +
-               "email <%= ENV['SUPPORT_ADDRESS'] %>." );
-      } else if ( data.status !== "completed" ) {
+        alert("Oops. Something went wrong. If this persists, please " +
+            "email <%= ENV['SUPPORT_ADDRESS'] %>.");
+      } else {
         updateModalContent( data.progress, data.total );
-        window.setTimeout( makeRestoreStatusRequest, 1000 );
+        if ( data.status !== "completed" ) {
+          window.setTimeout(makeRestoreStatusRequest, 1000);
+        }
       }
     },
     failure: function () {

--- a/app/views/stats/_options.html.erb
+++ b/app/views/stats/_options.html.erb
@@ -163,7 +163,7 @@
                 <div class="input-group" id="restore-form-group">
                   <label for="file">Backup file (*.jscor):</label>
                   <%= file_field_tag 'file', required: true %>
-                  <%#= text_field 'test_field', required: true %>
+                  <%#= text_field_tag 'test_field', nil, required: true %>
                 </div>
               </div>
               <div class="col-xs-12 col-compact">

--- a/app/views/stats/_options.html.erb
+++ b/app/views/stats/_options.html.erb
@@ -162,7 +162,7 @@
               <div class="col-xs-12 col-compact">
                 <div class="input-group" id="restore-form-group">
                   <label for="file">Backup file (*.jscor):</label>
-                  <%= file_field_tag 'file', required: true %>
+                  <%= file_field_tag 'backup_file', required: true %>
                   <%#= text_field_tag 'test_field', nil, required: true %>
                 </div>
               </div>

--- a/app/views/stats/_options.html.erb
+++ b/app/views/stats/_options.html.erb
@@ -143,7 +143,10 @@
        aria-labelledby="restore-modal-label">
     <div class="modal-dialog" role="document">
       <div class="modal-content">
-        <%= form_with(url: restore_path, multipart: true) do %>
+        <%= form_with(url: restore_path,
+                      method: 'post',
+                      multipart: true,
+                      id: 'restore-form') do %>
 
           <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-label="Close">
@@ -155,11 +158,12 @@
           </div>
 
           <div class="modal-body">
-            <div class="row">
+            <div class="row" id="restore-modal-content">
               <div class="col-xs-12 col-compact">
-                <div class="input-group" id="restore-form">
+                <div class="input-group" id="restore-form-group">
                   <label for="file">Backup file (*.jscor):</label>
                   <%= file_field_tag 'file', required: true %>
+                  <%#= text_field 'test_field', required: true %>
                 </div>
               </div>
               <div class="col-xs-12 col-compact">
@@ -176,7 +180,10 @@
             <button type="button" class="btn btn-default" data-dismiss="modal">
               Close
             </button>
-            <%= submit_tag 'Restore', class: 'btn btn-primary', id: 'restore-submit-button' %>
+            <%= submit_tag('Restore',
+                           id: 'restore-submit-button',
+                           class: 'btn btn-primary',
+                           data: { disable_with: 'Restoring...' }) %>
           </div> <!-- modal-footer -->
 
         <% end %>

--- a/app/views/stats/_options.html.erb
+++ b/app/views/stats/_options.html.erb
@@ -17,7 +17,6 @@
     <div id="backup-sentence" class="isolated-sentence">
       Download a backup file of your games by clicking
       <% if current_user?(@user) %>
-        <%# link_to 'here', backup_path %>.
         <a href="#" id="backup-link">here</a>.
       <% else %>
         <span class="disabled">here</span>.
@@ -163,7 +162,6 @@
                 <div class="input-group" id="restore-form-group">
                   <label for="file">Backup file (*.jscor):</label>
                   <%= file_field_tag 'backup_file', required: true %>
-                  <%#= text_field_tag 'test_field', nil, required: true %>
                 </div>
               </div>
               <div class="col-xs-12 col-compact">

--- a/app/views/stats/_options.html.erb
+++ b/app/views/stats/_options.html.erb
@@ -14,14 +14,16 @@
     <div class="isolated-sentence">
       (<a href="#" data-toggle="modal" data-target="#why-backup-modal">Why back up?</a>)
     </div>
-    <div class="isolated-sentence">
+    <div id="backup-sentence" class="isolated-sentence">
       Download a backup file of your games by clicking
       <% if current_user?(@user) %>
-        <%= link_to 'here', backup_path %>.
+        <%# link_to 'here', backup_path %>.
+        <a href="#" id="backup-link">here</a>.
       <% else %>
         <span class="disabled">here</span>.
       <% end %>
     </div>
+    <a href="#" id="invisible-download-link" style="display: none;"></a>
     <div class="isolated-sentence">
       Add games from a previously-generated backup file
       <% if current_user?(@user) %>

--- a/app/views/stats/_options.html.erb
+++ b/app/views/stats/_options.html.erb
@@ -158,7 +158,7 @@
           </div>
 
           <div class="modal-body">
-            <div class="row" id="restore-modal-content">
+            <div class="row" id="restore-modal-body">
               <div class="col-xs-12 col-compact">
                 <div class="input-group" id="restore-form-group">
                   <label for="file">Backup file (*.jscor):</label>

--- a/app/views/stats/_options.html.erb
+++ b/app/views/stats/_options.html.erb
@@ -10,7 +10,7 @@
   <hr />
   <br />
   <div class="clearfix">
-    <h2>Back up/Restore</h2>
+    <h2>Backup/Restore</h2>
     <div class="isolated-sentence">
       (<a href="#" data-toggle="modal" data-target="#why-backup-modal">Why back up?</a>)
     </div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,6 +57,10 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
+  # WARNING: This in an in-process adapter, and the queue will be emptied on
+  #          each restart. Since it's only used for backup and restore (two
+  #          very rarely used features), this should be acceptable.
+  config.active_job.queue_adapter = :async
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "j_scorer_production"

--- a/config/initializers/activejob_status.rb
+++ b/config/initializers/activejob_status.rb
@@ -1,0 +1,2 @@
+ActiveJob::Status.store = ActiveSupport::Cache::MemoryStore.new
+ActiveJob::Status.options = { expires_in: 24.hours.to_i }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   delete 'delete/:game_id' => 'games#destroy', as: :delete
 
   get 'backup' => 'backups#new'
+  get 'backup/:backup_id' => 'backups#status'
   post 'restore' => 'backups#restore'
 
   # Allow only Ajax requests to the following routes:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,8 +28,7 @@ Rails.application.routes.draw do
   get 'game' => 'games#game', as: :game
   delete 'delete/:game_id' => 'games#destroy', as: :delete
 
-  get 'backup' => 'backups#new'
-  get 'backup/:backup_id' => 'backups#status'
+  get 'backup/:backup_id/download' => 'backups#download'
   post 'restore' => 'backups#restore'
 
   # Allow only Ajax requests to the following routes:
@@ -45,5 +44,8 @@ Rails.application.routes.draw do
     get 'stats/games' => 'stats#games', as: :games
     get 'sample/games' => 'stats#sample_games', as: :sample_games
     get 'shared/:user/games' => 'stats#shared_games', as: :shared_games
+
+    get 'backup' => 'backups#new'
+    get 'backup/:backup_id' => 'backups#status'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,6 @@ Rails.application.routes.draw do
   delete 'delete/:game_id' => 'games#destroy', as: :delete
 
   get 'backup/:backup_id/download' => 'backups#download'
-  post 'restore' => 'backups#restore'
 
   # Allow only Ajax requests to the following routes:
   constraints(->(req) { req.xhr? }) do
@@ -47,5 +46,7 @@ Rails.application.routes.draw do
 
     get 'backup' => 'backups#new'
     get 'backup/:backup_id' => 'backups#status'
+    post 'restore' => 'backups#restore'
+    get 'restore/:restore_id' => 'backups#restore_progress'
   end
 end

--- a/test/controllers/backups_controller_test.rb
+++ b/test/controllers/backups_controller_test.rb
@@ -9,14 +9,14 @@ class BackupsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should redirect new when not logged in' do
-    get '/backup'
+    get '/backup', xhr: true
     assert_not flash.empty?
     assert_redirected_to login_url
   end
 
   test 'should generate backup when logged in' do
     log_in_here(@user)
-    get '/backup'
+    get '/backup', xhr: true
     assert flash.empty?
     assert_response :success
   end

--- a/test/controllers/backups_controller_test.rb
+++ b/test/controllers/backups_controller_test.rb
@@ -22,7 +22,7 @@ class BackupsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should redirect restore when not logged in' do
-    post '/restore'
+    post '/restore', xhr: true
     assert_not flash.empty?
     assert_redirected_to login_url
   end
@@ -30,30 +30,32 @@ class BackupsControllerTest < ActionDispatch::IntegrationTest
   test 'restore should fail when given a bad file' do
     log_in_here(@user)
     assert_no_difference '@user.games.count' do
-      post '/restore', params: { file: @bad_backup }
+      post '/restore', xhr: true, params: { file: @bad_backup }
       assert_not flash.empty?
       assert_redirected_to root_url
     end
   end
 
-  test 'restore should succeed when given a good file' do
-    log_in_here(@user)
-    assert_difference '@user.games.count', 1 do
-      post '/restore', params: { file: @backup_file }
-      assert flash.empty?
-      assert_redirected_to stats_url
-    end
-  end
-
-  test 'restore should add duplicate games' do
-    log_in_here(@user)
-    assert_difference '@user.games.count', 2 do
-      post '/restore', params: { file: @backup_file }
-      assert flash.empty?
-      assert_redirected_to stats_url
-      post '/restore', params: { file: @backup_file_2 }
-      assert flash.empty?
-      assert_redirected_to stats_url
-    end
-  end
+  # TODO: These are temporarily disabled until new implementation
+  #       details are determined.
+  # test 'restore should succeed when given a good file' do
+  #   log_in_here(@user)
+  #   assert_difference '@user.games.count', 1 do
+  #     post '/restore', xhr: true, params: { file: @backup_file }
+  #     assert flash.empty?
+  #     assert_redirected_to stats_url
+  #   end
+  # end
+  #
+  # test 'restore should add duplicate games' do
+  #   log_in_here(@user)
+  #   assert_difference '@user.games.count', 2 do
+  #     post '/restore', xhr: true, params: { file: @backup_file }
+  #     assert flash.empty?
+  #     assert_redirected_to stats_url
+  #     post '/restore', xhr: true, params: { file: @backup_file_2 }
+  #     assert flash.empty?
+  #     assert_redirected_to stats_url
+  #   end
+  # end
 end

--- a/test/jobs/restore_from_backup_job_test.rb
+++ b/test/jobs/restore_from_backup_job_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+# Note: This needs to inherit from IntegrationTest to pull in the
+#       fixture_file_upload method.
+class RestoreFromBackupJobTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:dave)
+    backup_file = fixture_file_upload('files/utoc_backup.jscor', 'application/octet-stream')
+    @games = BackupsController.new.parse_file(backup_file)
+  end
+
+  test 'should succeed when given a good file' do
+    log_in_here(@user)
+    assert_difference '@user.games.count', 1 do
+      RestoreFromBackupJob.perform_now(@user, @games)
+    end
+  end
+
+  test 'will restore duplicate games' do
+    log_in_here(@user)
+    assert_difference '@user.games.count', 2 do
+      RestoreFromBackupJob.perform_now(@user, @games)
+      RestoreFromBackupJob.perform_now(@user, @games)
+    end
+  end
+end


### PR DESCRIPTION
This will prevent timeout errors, as the features frequently take longer than the timeout threshold.

This implementation isn't ideal. Restorations or backup file generations in progress will be terminated on server restarts, but these features are used so rarely that I don't anticipate that being a problem.

This is certainly a big improvement over the current status, where a user with a couple thousand games or more would be completely unable to download a backup file, and a backup file with more than about three dozen games wouldn't restore.