### PR TITLE
fix: strip periods from new topic_string

### DIFF
--- a/app/models/concerns/topicable.rb
+++ b/app/models/concerns/topicable.rb
@@ -11,20 +11,21 @@ module Topicable
   private
 
   def update_topics!
-    topics_array = []
-    topic_names_array.each do |topic_name|
+    topics_array = topic_names_array.each_with_object([]) do |topic_name, array|
       topic = game.user.topics.where('lower(name) = ?', topic_name.downcase)
                   .first_or_create(name: topic_name)
-      topics_array << topic if topic.valid?
+      array << topic if topic.valid?
     end
     self.topics = topics_array
   end
 
   def topic_names_array
     return [] if topics_string.nil?
+
     topics_string.strip                 # Remove leading/trailing whitespace.
                  .squeeze(' ')          # Compress any consecutive spaces.
                  .gsub(/\s?,\s?/, ',')  # Remove any whitespace around commas.
+                 .delete('.')           # Remove any periods.
                  .split(',')            # Convert to array of strings.
                  .uniq(&:downcase)      # Remove any duplicates from array.
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   get 'sample' => 'stats#sample'
   get 'shared/:user' => 'stats#shared', as: :shared
 
-  get 'stats/topic/:topic' => 'stats#topic', as: :topic
+  get 'stats/topic/:topic', to: 'stats#topic', as: :topic, constraints: { topic: /[^\/]+/ }
   get 'sample/topic/:topic' => 'stats#sample_topic', as: :sample_topic
   get 'shared/:user/topic/:topic' => 'stats#shared_topic', as: :shared_topic
 


### PR DESCRIPTION
This commit fixes a bug where periods were not
being stripped from the topic_string.

periods caused issues with displaying stats for
topics with periods in their name, e.g. 'u.s.
history'.

This fix simply removes the period when the topic
is created.

TODO: remove periods from all topic_strings in db

write tests for this to see if it has unintended
effects.